### PR TITLE
(FEAT) Add quality of life utilities

### DIFF
--- a/lib/pwsh/util.rb
+++ b/lib/pwsh/util.rb
@@ -109,6 +109,15 @@ module Pwsh
         raise "unsupported type #{object.class} of value '#{object}'"
       end
     end
+
+    # Return the representative string of a PowerShell hash for a custom object property to be used in selecting or filtering.
+    # The script block for the expression must be passed as the string you want interpolated into the hash; this method does
+    # not do any of the additional work of interpolation for you as the type sits inside a code block inside a hash.
+    #
+    # @return [String] representation of a PowerShell hash with the keys 'Name' and 'Expression'
+    def custom_powershell_property(name, expression)
+      "@{Name = '#{name}'; Expression = {#{expression}}}"
+    end
   end
 end
 

--- a/lib/pwsh/util.rb
+++ b/lib/pwsh/util.rb
@@ -29,6 +29,52 @@ module Pwsh
 
       invalid_paths
     end
+
+    # Return a string converted to snake_case
+    #
+    # @return [String] snake_cased string
+    def snake_case(string)
+      # Implementation copied from: https://github.com/rubyworks/facets/blob/master/lib/core/facets/string/snakecase.rb
+      # gsub(/::/, '/').
+      string.gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
+            .gsub(/([a-z\d])([A-Z])/, '\1_\2')
+            .tr('-', '_')
+            .gsub(/\s/, '_')
+            .gsub(/__+/, '_')
+            .downcase
+    end
+
+    # Iterate through a hashes keys, snake_casing them
+    #
+    # @return [Hash] Hash with all keys snake_cased
+    def snake_case_hash_keys(hash)
+      modified_hash = {}
+      hash.each do |key, value|
+        value = snake_case_hash_keys(value) if value.is_a?(Hash)
+        modified_hash[snake_case(key.to_s).to_sym] = value
+      end
+      modified_hash
+    end
+
+    # Return a string converted to PascalCase
+    #
+    # @return [String] PascalCased string
+    def pascal_case(string)
+      # Break word boundaries to snake case first
+      snake_case(string).split('_').collect(&:capitalize).join
+    end
+
+    # Iterate through a hashes keys, PascalCasing them
+    #
+    # @return [Hash] Hash with all keys PascalCased
+    def pascal_case_hash_keys(hash)
+      modified_hash = {}
+      hash.each do |key, value|
+        value = pascal_case_hash_keys(value) if value.is_a?(Hash)
+        modified_hash[pascal_case(key.to_s).to_sym] = value
+      end
+      modified_hash
+    end
   end
 end
 

--- a/spec/unit/pwsh/util_spec.rb
+++ b/spec/unit/pwsh/util_spec.rb
@@ -55,4 +55,81 @@ RSpec.describe Pwsh::Util do
       expect(described_class.invalid_directories?(empty_members)).to be false
     end
   end
+
+  let(:camel_case_hash) do
+    {
+      a: 1,
+      appleButter: %w[a b c],
+      someKeyValue: {
+        nestedKey: 1,
+        anotherNestedKey: 2
+      }
+    }
+  end
+  let(:kebab_case_hash) do
+    {
+      a: 1,
+      'apple-butter': %w[a b c],
+      'some-key-value': {
+        'nested-key': 1,
+        'another-nested-key': 2
+      }
+    }
+  end
+  let(:pascal_case_hash) do
+    {
+      A: 1,
+      AppleButter: %w[a b c],
+      SomeKeyValue: {
+        NestedKey: 1,
+        AnotherNestedKey: 2
+      }
+    }
+  end
+  let(:snake_case_hash) do
+    {
+      a: 1,
+      apple_butter: %w[a b c],
+      some_key_value: {
+        nested_key: 1,
+        another_nested_key: 2
+      }
+    }
+  end
+  let(:camel_case_string) { 'thisIsAString' }
+  let(:kebab_case_string) { 'this-is-a-string' }
+  let(:pascal_case_string) { 'ThisIsAString' }
+  let(:snake_case_string) { 'this_is_a_string' }
+
+  context '.snake_case' do
+    it 'converts a string to snake_case' do
+      expect(described_class.snake_case(camel_case_string)).to eq snake_case_string
+      expect(described_class.snake_case(kebab_case_string)).to eq snake_case_string
+      expect(described_class.snake_case(pascal_case_string)).to eq snake_case_string
+    end
+  end
+
+  context '.snake_case_hash_keys' do
+    it 'snake_cases the keys in a passed hash' do
+      expect(described_class.snake_case_hash_keys(camel_case_hash)).to eq snake_case_hash
+      expect(described_class.snake_case_hash_keys(kebab_case_hash)).to eq snake_case_hash
+      expect(described_class.snake_case_hash_keys(pascal_case_hash)).to eq snake_case_hash
+    end
+  end
+
+  context '.pascal_case' do
+    it 'converts a string to PascalCase' do
+      expect(described_class.pascal_case(camel_case_string)).to eq pascal_case_string
+      expect(described_class.pascal_case(kebab_case_string)).to eq pascal_case_string
+      expect(described_class.pascal_case(snake_case_string)).to eq pascal_case_string
+    end
+  end
+
+  context '.pascal_case_hash_keys' do
+    it 'PascalCases the keys in a passed hash' do
+      expect(described_class.pascal_case_hash_keys(camel_case_hash)).to eq pascal_case_hash
+      expect(described_class.pascal_case_hash_keys(kebab_case_hash)).to eq pascal_case_hash
+      expect(described_class.pascal_case_hash_keys(snake_case_hash)).to eq pascal_case_hash
+    end
+  end
 end

--- a/spec/unit/pwsh/util_spec.rb
+++ b/spec/unit/pwsh/util_spec.rb
@@ -192,4 +192,10 @@ RSpec.describe Pwsh::Util do
       expect { described_class.format_powershell_value(described_class) }.to raise_error(/unsupported type Module/)
     end
   end
+
+  context '.custom_powershell_property' do
+    it 'returns a powershell hash with the name and expression keys' do
+      expect(described_class.custom_powershell_property('apple', '$_.SomeValue / 5')).to eq("@{Name = 'apple'; Expression = {$_.SomeValue / 5}}")
+    end
+  end
 end


### PR DESCRIPTION
This commit adds four new utilities to the gem:

- `snake_case`: returns a string which is `snake_cased`.
- `snake_case_hash_keys`: returns a hash in which all of the keys are `snake_cased`.
- `pascal_case`:  returns a string which is `PascalCased`.
- `pascal_case_hash_keys`:  returns a hash in which all of the keys are `PascalCased`.
- `escape_quotes`: ensures that any string passed will be returned wrapped in double quotes for passing into PowerShell; this is because of the interpolation required when sending code to the PowerShell manager.
- `format_powershell_value`: converts ruby data types into strings of their PowerShell representation for interpolation and passing to the PowerShell manager.
- `custom_powershell_property`: takes a name and an expression and returns a string which represents a PowerShell custom object property hash. The expression being passed must already be an interpolated string as this method does not do any additional work for interpolation; whatever is passed is what will end up as PowerShell code in the expression script block.

These methods make interaction between Ruby and PowerShell a little easier by handling common translation problems when moving between Ruby and PowerShell objects.