### PR TITLE
(FEAT) Ensure hash key casing methods work on arrays

### DIFF
--- a/lib/pwsh/util.rb
+++ b/lib/pwsh/util.rb
@@ -49,9 +49,12 @@ module Pwsh
     #
     # @return [Hash] Hash with all keys snake_cased
     def snake_case_hash_keys(hash)
+      return hash.map { |h| snake_case_hash_keys(h) } if hash.is_a?(Array)
+      return hash unless hash.is_a?(Hash)
+
       modified_hash = {}
       hash.each do |key, value|
-        value = snake_case_hash_keys(value) if value.is_a?(Hash)
+        value = snake_case_hash_keys(value)
         modified_hash[snake_case(key.to_s).to_sym] = value
       end
       modified_hash
@@ -69,9 +72,12 @@ module Pwsh
     #
     # @return [Hash] Hash with all keys PascalCased
     def pascal_case_hash_keys(hash)
+      return hash.map { |h| pascal_case_hash_keys(h) } if hash.is_a?(Array)
+      return hash unless hash.is_a?(Hash)
+
       modified_hash = {}
       hash.each do |key, value|
-        value = pascal_case_hash_keys(value) if value.is_a?(Hash)
+        value = pascal_case_hash_keys(value)
         modified_hash[pascal_case(key.to_s).to_sym] = value
       end
       modified_hash

--- a/lib/pwsh/util.rb
+++ b/lib/pwsh/util.rb
@@ -31,41 +31,50 @@ module Pwsh
       invalid_paths
     end
 
-    # Return a string converted to snake_case
+    # Return a string or symbol converted to snake_case
     #
     # @return [String] snake_cased string
-    def snake_case(string)
+    def snake_case(object)
       # Implementation copied from: https://github.com/rubyworks/facets/blob/master/lib/core/facets/string/snakecase.rb
       # gsub(/::/, '/').
-      string.gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
-            .gsub(/([a-z\d])([A-Z])/, '\1_\2')
-            .tr('-', '_')
-            .gsub(/\s/, '_')
-            .gsub(/__+/, '_')
-            .downcase
+      should_symbolize = object.is_a?(Symbol)
+      raise "snake_case method only handles strings and symbols, passed a #{object.class}: #{object}" unless should_symbolize || object.is_a?(String)
+
+      text = object.to_s
+                   .gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
+                   .gsub(/([a-z\d])([A-Z])/, '\1_\2')
+                   .tr('-', '_')
+                   .gsub(/\s/, '_')
+                   .gsub(/__+/, '_')
+                   .downcase
+      should_symbolize ? text.to_sym : text
     end
 
     # Iterate through a hashes keys, snake_casing them
     #
     # @return [Hash] Hash with all keys snake_cased
     def snake_case_hash_keys(object)
-      snake_case_proc = proc { |key| snake_case(key.to_s).to_sym }
+      snake_case_proc = proc { |key| snake_case(key) }
       apply_key_mutator(object, snake_case_proc)
     end
 
-    # Return a string converted to PascalCase
+    # Return a string or symbol converted to PascalCase
     #
     # @return [String] PascalCased string
-    def pascal_case(string)
+    def pascal_case(object)
+      should_symbolize = object.is_a?(Symbol)
+      raise "snake_case method only handles strings and symbols, passed a #{object.class}: #{object}" unless should_symbolize || object.is_a?(String)
+
       # Break word boundaries to snake case first
-      snake_case(string).split('_').collect(&:capitalize).join
+      text = snake_case(object.to_s).split('_').collect(&:capitalize).join
+      should_symbolize ? text.to_sym : text
     end
 
     # Iterate through a hashes keys, PascalCasing them
     #
     # @return [Hash] Hash with all keys PascalCased
     def pascal_case_hash_keys(object)
-      pascal_case_proc = proc { |key| pascal_case(key.to_s).to_sym }
+      pascal_case_proc = proc { |key| pascal_case(key) }
       apply_key_mutator(object, pascal_case_proc)
     end
 

--- a/spec/unit/pwsh/util_spec.rb
+++ b/spec/unit/pwsh/util_spec.rb
@@ -86,6 +86,25 @@ RSpec.describe Pwsh::Util do
       }
     }
   end
+  let(:pascal_case_hash_in_an_array) do
+    [
+      'just a string',
+      {
+        SomeKey: 'a value'
+      },
+      1,
+      {
+        AnotherKey: {
+          NestedKey: 1,
+          NestedArray: [
+            1,
+            'another string',
+            { SuperNestedKey: 'value' }
+          ]
+        }
+      }
+    ]
+  end
   let(:snake_case_hash) do
     {
       a: 1,
@@ -95,6 +114,25 @@ RSpec.describe Pwsh::Util do
         another_nested_key: 2
       }
     }
+  end
+  let(:snake_case_hash_in_an_array) do
+    [
+      'just a string',
+      {
+        some_key: 'a value'
+      },
+      1,
+      {
+        another_key: {
+          nested_key: 1,
+          nested_array: [
+            1,
+            'another string',
+            { super_nested_key: 'value' }
+          ]
+        }
+      }
+    ]
   end
   let(:camel_case_string) { 'thisIsAString' }
   let(:kebab_case_string) { 'this-is-a-string' }
@@ -114,6 +152,7 @@ RSpec.describe Pwsh::Util do
       expect(described_class.snake_case_hash_keys(camel_case_hash)).to eq snake_case_hash
       expect(described_class.snake_case_hash_keys(kebab_case_hash)).to eq snake_case_hash
       expect(described_class.snake_case_hash_keys(pascal_case_hash)).to eq snake_case_hash
+      expect(described_class.snake_case_hash_keys(pascal_case_hash_in_an_array)).to eq snake_case_hash_in_an_array
     end
   end
 
@@ -130,6 +169,7 @@ RSpec.describe Pwsh::Util do
       expect(described_class.pascal_case_hash_keys(camel_case_hash)).to eq pascal_case_hash
       expect(described_class.pascal_case_hash_keys(kebab_case_hash)).to eq pascal_case_hash
       expect(described_class.pascal_case_hash_keys(snake_case_hash)).to eq pascal_case_hash
+      expect(described_class.pascal_case_hash_keys(snake_case_hash_in_an_array)).to eq pascal_case_hash_in_an_array
     end
   end
 


### PR DESCRIPTION
Prior to this commit the hash key casing methods, `snake_case_hash_keys` and `pascal_case_hash_keys`, only properly handled hashes, not hashes inside arrays or other objects.

Now, if passed an array, the methods will iterate over each item in the array, recursively casing any keys discovered in hashes. Additionally, they will not error if passed any objects which are not hashes or arrays; instead, they will return that object as-is.