### PR TITLE
(FEAT) Add method for symbolizing hash keys

### DIFF
--- a/lib/pwsh/util.rb
+++ b/lib/pwsh/util.rb
@@ -84,6 +84,22 @@ module Pwsh
       text.gsub("'", "''")
     end
 
+    # Ensure that all keys in a hash are symbols, not strings.
+    #
+    # @return [Hash] a hash whose keys have been converted to symbols.
+    def symbolize_hash_keys(hash)
+      if hash.is_a?(Hash)
+        hash.inject({}) do |memo, (k, v)| # rubocop:disable Style/EachWithObject
+          memo[k.to_sym] = symbolize_hash_keys(v)
+          memo
+        end
+      elsif hash.is_a?(Array)
+        hash.map { |i| symbolize_hash_keys(i) }
+      else
+        hash
+      end
+    end
+
     # Convert a ruby value into a string to be passed along to PowerShell for interpolation in a command
     # Handles:
     # - Strings

--- a/spec/unit/pwsh/util_spec.rb
+++ b/spec/unit/pwsh/util_spec.rb
@@ -133,6 +133,51 @@ RSpec.describe Pwsh::Util do
     end
   end
 
+  context '.symbolize_hash_keys' do
+    let(:array_with_string_keys_in_hashes) do
+      [
+        'just a string',
+        {
+          'some_key' => 'a value'
+        },
+        1,
+        {
+          'another_key' => {
+            'nested_key' => 1,
+            'nested_array' => [
+              1,
+              'another string',
+              { 'super_nested_key' => 'value' }
+            ]
+          }
+        }
+      ]
+    end
+    let(:array_with_symbol_keys_in_hashes) do
+      [
+        'just a string',
+        {
+          some_key: 'a value'
+        },
+        1,
+        {
+          another_key: {
+            nested_key: 1,
+            nested_array: [
+              1,
+              'another string',
+              { super_nested_key: 'value' }
+            ]
+          }
+        }
+      ]
+    end
+
+    it 'converts all string hash keys into symbols' do
+      expect(described_class.symbolize_hash_keys(array_with_string_keys_in_hashes)).to eq array_with_symbol_keys_in_hashes
+    end
+  end
+
   context '.escape_quotes' do
     it 'handles single quotes' do
       expect(described_class.escape_quotes("The 'Cats' go 'meow'!")).to match(/The ''Cats'' go ''meow''!/)


### PR DESCRIPTION
This commit adds a new utility method which will take a hash or an array and recursively turn any discovered hash keys from string keys into symbol keys and return the symbolized hash.