### PR TITLE
(MAINT) Update rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,7 +19,7 @@ Metrics/AbcSize:
 
 # requires 2.3's squiggly HEREDOC support, which we can't use, yet
 # see http://www.virtuouscode.com/2016/01/06/about-the-ruby-squiggly-heredoc-syntax/
-Layout/IndentHeredoc:
+Layout/HeredocIndentation:
   Enabled: false
 # Need to ignore rubocop complaining about the name of the library.
 Naming/FileName:

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :test do
   gem 'rspec', '~> 3.0'
   gem 'rspec-collection_matchers', '~> 1.0'
   gem 'rspec-its', '~> 1.0'
-  gem 'rubocop'
+  gem 'rubocop', '>= 0.77'
   gem 'rubocop-rspec'
   gem 'simplecov'
 end


### PR DESCRIPTION
Prior to this commit rubocop runs in Travis failed on a renamed cop.