### PR TITLE
(MODULES-10389) Only load pwshlib if functionality present

### DIFF
--- a/lib/puppet/feature/pwshlib.rb
+++ b/lib/puppet/feature/pwshlib.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require 'puppet/util/feature'
+
+Puppet.features.add(:pwshlib, libs: ['pwshlib'])


### PR DESCRIPTION
### Description
This is a hotfix to resolve an issue customers are seeing after the `v.3.0.0` release of the `puppetlabs-powershell` module. Adding a pwshlib feature will ensure that the powershell provider is only loaded if the functionality is detected. On Linux systems, this should prevent Puppet from throwing the following error:
```
Error: Could not autoload puppet/provider/exec/powershell: Could not load the "ruby-pwsh" library; is the dependency module puppetlabs-pwshlib installed in this environment?
Error: Could not autoload puppet/type/exec: Could not autoload puppet/provider/exec/powershell: Could not load the "ruby-pwsh" library; is the dependency module puppetlabs-pwshlib installed in this environment?
Error: Could not run: Could not autoload puppet/type/exec: Could not autoload puppet/provider/exec/powershell: Could not load the "ruby-pwsh" library; is the dependency module puppetlabs-pwshlib installed in this environment?
```
See [MODULES-10389](https://tickets.puppetlabs.com/browse/MODULES-10389) for more details