### PR TITLE
Avoid use of Ruby 2.3+ features for specified Puppet support

### DIFF
--- a/lib/pwsh.rb
+++ b/lib/pwsh.rb
@@ -54,7 +54,7 @@ module Pwsh
       if manager.nil? || !manager.alive?
         # ignore any errors trying to tear down this unusable instance
         begin
-          manager&.exit
+          manager.exit if manager # rubocop:disable Style/SafeNavigation
         rescue
           nil
         end

--- a/lib/pwsh/util.rb
+++ b/lib/pwsh/util.rb
@@ -117,7 +117,9 @@ module Pwsh
     #
     # @return [String] representation of the value for interpolation
     def format_powershell_value(object)
-      if %i[true false].include?(object) || %w[trueclass falseclass].include?(object.class.name.downcase) # rubocop:disable Lint/BooleanSymbol
+      # rubocop:disable Style/SymbolArray
+      if [:true, :false].include?(object) || %w[trueclass falseclass].include?(object.class.name.downcase) # rubocop:disable Lint/BooleanSymbol
+        # rubocop:enable Style/SymbolArray
         "$#{object}"
       elsif object.class.name == 'Symbol' || object.class.ancestors.include?(Numeric)
         object.to_s


### PR DESCRIPTION
Puppetserver 4.10.0, 5.3.10, et al use JRuby 1.9

As the metadata specifies support for these Puppet versions, use of Ruby-isms from Ruby 2.3+ aren't supported.

Fixes #28