### PR TITLE
Correct supported Puppet lower bound to 5.5.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -76,7 +76,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.10.0 < 7.0.0"
+      "version_requirement": ">= 5.5.0 < 7.0.0"
     }
   ],
   "pdk-version": "1.13.0",


### PR DESCRIPTION
Prior to this commit the metadata erroneously claimed support for 4x versions of Puppet, on which it has not been tested and would fail to run due to the safe navigation feature introduced in Ruby 2.3.