### PR TITLE
 Ruby 1.9.3 compatibility

### DIFF
--- a/lib/pwsh.rb
+++ b/lib/pwsh.rb
@@ -516,7 +516,7 @@ Invoke-PowerShellUserCode @params
     def length_prefixed_string(data)
       msg = data.encode(Encoding::UTF_8)
       # https://ruby-doc.org/core-1.9.3/Array.html#method-i-pack
-      [msg.bytes.length].pack('V') + msg.force_encoding(Encoding::BINARY)
+      [msg.bytes.count].pack('V') + msg.force_encoding(Encoding::BINARY)
     end
 
     # Writes binary-encoded data to the PowerShell manager process via the pipe.

--- a/lib/pwsh.rb
+++ b/lib/pwsh.rb
@@ -356,7 +356,7 @@ Invoke-PowerShellUserCode @params
     # @return [Array[String]] array of command flags to pass Windows PowerShell
     def self.powershell_args
       ps_args = ['-NoProfile', '-NonInteractive', '-NoLogo', '-ExecutionPolicy', 'Bypass']
-      ps_args << '-Command' unless windows_powershell_supported?
+      #ps_args << '-Command' unless windows_powershell_supported?
 
       ps_args
     end

--- a/lib/pwsh.rb
+++ b/lib/pwsh.rb
@@ -516,7 +516,7 @@ Invoke-PowerShellUserCode @params
     def length_prefixed_string(data)
       msg = data.encode(Encoding::UTF_8)
       # https://ruby-doc.org/core-1.9.3/Array.html#method-i-pack
-      [msg.bytes.count].pack('V') + msg.force_encoding(Encoding::BINARY)
+      [msg.bytes.respond_to?(:length) ? msg.bytes.length : msg.bytes.count].pack('V') + msg.force_encoding(Encoding::BINARY)
     end
 
     # Writes binary-encoded data to the PowerShell manager process via the pipe.

--- a/lib/pwsh/util.rb
+++ b/lib/pwsh/util.rb
@@ -117,7 +117,7 @@ module Pwsh
     #
     # @return [String] representation of the value for interpolation
     def format_powershell_value(object)
-      if %i[true false].include?(object) || %w[trueclass falseclass].include?(object.class.name.downcase) # rubocop:disable Lint/BooleanSymbol
+      if [true, false].include?(object) || %w[trueclass falseclass].include?(object.class.name.downcase) # rubocop:disable Lint/BooleanSymbol
         "$#{object}"
       elsif object.class.name == 'Symbol' || object.class.ancestors.include?(Numeric)
         object.to_s


### PR DESCRIPTION
Mentioned in #31

The reason is "Lost the source code for required binary components".

Readme code runs after applying these changes.