### PR TITLE
(MAINT) Ensure dsc provider finds dsc resources during agent run

### DIFF
--- a/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
+++ b/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
@@ -278,11 +278,15 @@ class Puppet::Provider::DscBaseProvider < Puppet::ResourceApi::SimpleProvider
     end
     resource[:dsc_invoke_method] = dsc_invoke_method
 
-    # Because Puppet adds all of the modules to the LOAD_PATH we can be sure that the appropriate module lives here
+    # Because Puppet adds all of the modules to the LOAD_PATH we can be sure that the appropriate module lives here during an apply;
     # PROBLEM: This currently uses the downcased name, we need to capture the module name in the metadata I think.
+    # During a Puppet agent run, the code lives in the cache so we can use the file expansion to discover the correct folder.
     root_module_path = $LOAD_PATH.select { |path| path.match?(%r{#{resource[:dscmeta_module_name].downcase}/lib}) }.first
-    resource[:vendored_modules_path] = File.expand_path(root_module_path + '/puppet_x/dsc_resources')
-    # resource[:vendored_modules_path] = File.expand_path(Pathname.new(__FILE__).dirname + '../../../' + 'puppet_x/dsc_resources')
+    resource[:vendored_modules_path] = if root_module_path.nil?
+                                         File.expand_path(Pathname.new(__FILE__).dirname + '../../../' + 'puppet_x/dsc_resources')
+                                       else
+                                         File.expand_path(root_module_path + '/puppet_x/dsc_resources')
+                                       end
     resource[:attributes] = nil
     context.debug("should_to_resource: #{resource.inspect}")
     resource


### PR DESCRIPTION
Prior to this commit the dsc_base_provider used the LOAD_PATH
to find the appropriate Puppet module and retrieve the DSC
resources from it; this does not work in a puppet agent run,
because the resources are placed flatly on disc in lib/puppet
and lib/puppet_x, not per-module as with a puppet apply run.

This commit adds a handler to fall back on relative paths for
discovery in the case where the module cannot be found in the
LOAD_PATH.