### PR TITLE
(GH-55) Handle intentionally empty arrays

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@
 version: 1.1.x.{build}
 branches:
   only:
-    - master
+    - main
     - release
 clone_depth: 10
 environment:

--- a/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
+++ b/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
@@ -15,6 +15,7 @@ class Puppet::Provider::DscBaseProvider < Puppet::ResourceApi::SimpleProvider
     @@cached_canonicalized_resource = []
     @@cached_query_results = []
     @@logon_failures = []
+    super
   end
 
   # Look through a cache to retrieve the hashes specified, if they have been cached.
@@ -158,9 +159,7 @@ class Puppet::Provider::DscBaseProvider < Puppet::ResourceApi::SimpleProvider
     context.debug("retrieving #{name_hash.inspect}")
 
     # Do not bother running if the logon credentials won't work
-    unless name_hash[:dsc_psdscrunascredential].nil?
-      return name_hash if logon_failed_already?(name_hash[:dsc_psdscrunascredential])
-    end
+    return name_hash if !name_hash[:dsc_psdscrunascredential].nil? && logon_failed_already?(name_hash[:dsc_psdscrunascredential])
 
     query_props = name_hash.select { |k, v| mandatory_get_attributes(context).include?(k) || (k == :dsc_psdscrunascredential && !v.nil?) }
     resource = should_to_resource(query_props, context, 'get')
@@ -194,7 +193,7 @@ class Puppet::Provider::DscBaseProvider < Puppet::ResourceApi::SimpleProvider
     # Canonicalize the results to match the type definition representation;
     # failure to do so will prevent the resource_api from comparing the result
     # to the should hash retrieved from the resource definition in the manifest.
-    data.keys.each do |key|
+    data.keys.each do |key| # rubocop:disable Style/HashEachMethods
       type_key = "dsc_#{key.downcase}".to_sym
       data[type_key] = data.delete(key)
       camelcase_hash_keys!(data[type_key]) if data[type_key].is_a?(Enumerable)
@@ -234,9 +233,7 @@ class Puppet::Provider::DscBaseProvider < Puppet::ResourceApi::SimpleProvider
     context.debug("Invoking Set Method for '#{name}' with #{should.inspect}")
 
     # Do not bother running if the logon credentials won't work
-    unless should[:dsc_psdscrunascredential].nil?
-      return nil if logon_failed_already?(should[:dsc_psdscrunascredential])
-    end
+    return nil if !should[:dsc_psdscrunascredential].nil? && logon_failed_already?(should[:dsc_psdscrunascredential])
 
     apply_props = should.select { |k, _v| k.to_s =~ /^dsc_/ }
     resource = should_to_resource(apply_props, context, 'set')
@@ -288,9 +285,9 @@ class Puppet::Provider::DscBaseProvider < Puppet::ResourceApi::SimpleProvider
     # During a Puppet agent run, the code lives in the cache so we can use the file expansion to discover the correct folder.
     root_module_path = $LOAD_PATH.select { |path| path.match?(%r{#{resource[:dscmeta_module_name].downcase}/lib}) }.first
     resource[:vendored_modules_path] = if root_module_path.nil?
-                                         File.expand_path(Pathname.new(__FILE__).dirname + '../../../' + 'puppet_x/dsc_resources')
+                                         File.expand_path(Pathname.new(__FILE__).dirname + '../../../' + 'puppet_x/dsc_resources') # rubocop:disable Style/StringConcatenation
                                        else
-                                         File.expand_path(root_module_path + '/puppet_x/dsc_resources')
+                                         File.expand_path("#{root_module_path}/puppet_x/dsc_resources")
                                        end
     resource[:attributes] = nil
     context.debug("should_to_resource: #{resource.inspect}")
@@ -336,7 +333,7 @@ class Puppet::Provider::DscBaseProvider < Puppet::ResourceApi::SimpleProvider
   # @return [Enumerable] returns the input object with hash keys recursively camelCased
   def camelcase_hash_keys!(enumerable)
     if enumerable.is_a?(Hash)
-      enumerable.keys.each do |key|
+      enumerable.keys.each do |key| # rubocop:disable Style/HashEachMethods
         name = key.dup
         name[0] = name[0].downcase
         enumerable[name] = enumerable.delete(key)
@@ -446,8 +443,7 @@ class Puppet::Provider::DscBaseProvider < Puppet::ResourceApi::SimpleProvider
   # @param credential_hash [Hash] the Properties which define the PSCredential Object
   # @return [String] A line of PowerShell which defines the PSCredential object and stores it to a variable
   def format_pscredential(variable_name, credential_hash)
-    definition = "$#{variable_name} = New-PSCredential -User #{credential_hash['user']} -Password '#{credential_hash['password']}' # PuppetSensitive"
-    definition
+    "$#{variable_name} = New-PSCredential -User #{credential_hash['user']} -Password '#{credential_hash['password']}' # PuppetSensitive"
   end
 
   # Parses a resource definition (as from `should_to_resource`) for any properties which are CIM instances
@@ -527,8 +523,7 @@ class Puppet::Provider::DscBaseProvider < Puppet::ResourceApi::SimpleProvider
     # EVEN WORSE HACK - this one we can't even be sure it's a cim instance...
     # but I don't _think_ anything but nested cim instances show up as hashes inside an array
     definition = definition.gsub('@(@{', '[CimInstance[]]@(@{')
-    definition = interpolate_variables(definition)
-    definition
+    interpolate_variables(definition)
   end
 
   # Munge a resource definition (as from `should_to_resource`) into valid PowerShell which represents
@@ -567,7 +562,7 @@ class Puppet::Provider::DscBaseProvider < Puppet::ResourceApi::SimpleProvider
     params_block = interpolate_variables("$InvokeParams = #{format(params)}")
     # HACK: Handle intentionally empty arrays - need to strongly type them because
     # CIM instances do not do a consistent job of casting an empty array properly.
-    empty_array_parameters = resource[:parameters].select { |k,v| v[:value].empty? }
+    empty_array_parameters = resource[:parameters].select { |_k, v| v[:value].empty? }
     empty_array_parameters.each do |name, properties|
       param_block_name = name.to_s.gsub(/^dsc_/, '')
       params_block = params_block.gsub("#{param_block_name} = @()", "#{param_block_name} = [#{properties[:mof_type]}]@()")
@@ -589,11 +584,11 @@ class Puppet::Provider::DscBaseProvider < Puppet::ResourceApi::SimpleProvider
   def ps_script_content(resource)
     template_path = File.expand_path('../', __FILE__)
     # Defines the helper functions
-    functions     = File.new(template_path + '/invoke_dsc_resource_functions.ps1').read
+    functions     = File.new("#{template_path}/invoke_dsc_resource_functions.ps1").read
     # Defines the response hash and the runtime settings
-    preamble      = File.new(template_path + '/invoke_dsc_resource_preamble.ps1').read
+    preamble      = File.new("#{template_path}/invoke_dsc_resource_preamble.ps1").read
     # The postscript defines the invocation error and result handling; expects `$InvokeParams` to be defined
-    postscript    = File.new(template_path + '/invoke_dsc_resource_postscript.ps1').read
+    postscript    = File.new("#{template_path}/invoke_dsc_resource_postscript.ps1").read
     # The blocks define the variables to define for the postscript.
     credential_block = prepare_credentials(resource)
     cim_instances_block = prepare_cim_instances(resource)
@@ -601,8 +596,7 @@ class Puppet::Provider::DscBaseProvider < Puppet::ResourceApi::SimpleProvider
     # clean them out of the temporary cache now that they're not needed; failure to do so can goof up future executions in this run
     clear_instantiated_variables!
 
-    content = [functions, preamble, credential_block, cim_instances_block, parameters_block, postscript].join("\n")
-    content
+    [functions, preamble, credential_block, cim_instances_block, parameters_block, postscript].join("\n")
   end
 
   # Convert a Puppet/Ruby value into a PowerShell representation. Requires some slight additional
@@ -626,15 +620,16 @@ class Puppet::Provider::DscBaseProvider < Puppet::ResourceApi::SimpleProvider
   # @param value [Object] The object to unwrap sensitive data inside of
   # @return [Object] The object with any sensitive strings unwrapped and annotated
   def unwrap(value)
-    if value.class.name == 'Puppet::Pops::Types::PSensitiveType::Sensitive'
+    case value
+    when Puppet::Pops::Types::PSensitiveType::Sensitive
       "#{value.unwrap}#PuppetSensitive"
-    elsif value.class.name == 'Hash'
+    when Hash
       unwrapped = {}
       value.each do |k, v|
         unwrapped[k] = unwrap(v)
       end
       unwrapped
-    elsif value.class.name == 'Array'
+    when Array
       unwrapped = []
       value.each do |v|
         unwrapped << unwrap(v)

--- a/lib/pwsh.rb
+++ b/lib/pwsh.rb
@@ -16,8 +16,7 @@ module Pwsh
   class Error < StandardError; end
   # Create an instance of a PowerShell host and manage execution of PowerShell code inside that host.
   class Manager
-    attr_reader :powershell_command
-    attr_reader :powershell_arguments
+    attr_reader :powershell_command, :powershell_arguments
 
     # We actually want this to be a class variable.
     @@instances = {} # rubocop:disable Style/ClassVars
@@ -70,7 +69,7 @@ module Pwsh
     def self.win32console_enabled?
       @win32console_enabled ||= defined?(Win32) &&
                                 defined?(Win32::Console) &&
-                                Win32::Console.class == Class
+                                Win32::Console.instance_of?(Class)
     end
 
     # TODO: This thing isn't called anywhere and the variable it sets is never referenced...

--- a/lib/pwsh/util.rb
+++ b/lib/pwsh/util.rb
@@ -117,16 +117,16 @@ module Pwsh
     #
     # @return [String] representation of the value for interpolation
     def format_powershell_value(object)
-      if %i[true false].include?(object) || %w[trueclass falseclass].include?(object.class.name.downcase) # rubocop:disable Lint/BooleanSymbol
+      if %i[true false].include?(object) || %w[trueclass falseclass].include?(object.class.name.downcase)
         "$#{object}"
-      elsif object.class.name == 'Symbol' || object.class.ancestors.include?(Numeric)
+      elsif object.instance_of?(Symbol) || object.class.ancestors.include?(Numeric)
         object.to_s
-      elsif object.class.name == 'String'
+      elsif object.instance_of?(String)
         "'#{escape_quotes(object)}'"
-      elsif object.class.name == 'Array'
-        '@(' + object.collect { |item| format_powershell_value(item) }.join(', ') + ')'
-      elsif object.class.name == 'Hash'
-        '@{' + object.collect { |k, v| format_powershell_value(k) + ' = ' + format_powershell_value(v) }.join('; ') + '}'
+      elsif object.instance_of?(Array)
+        "@(#{object.collect { |item| format_powershell_value(item) }.join(', ')})"
+      elsif object.instance_of?(Hash)
+        "@{#{object.collect { |k, v| "#{format_powershell_value(k)} = #{format_powershell_value(v)}" }.join('; ')}}"
       else
         raise "unsupported type #{object.class} of value '#{object}'"
       end

--- a/spec/unit/pwsh_spec.rb
+++ b/spec/unit/pwsh_spec.rb
@@ -76,14 +76,14 @@ RSpec.shared_examples 'a PowerShellCodeManager' do |ps_command, ps_args|
           # <Errno::EBADF: Bad file descriptor @ io_fillbuf - fd:10 >
           @bad_file_descriptor_regex ||= begin
             ebadf = Errno::EBADF.new
-            '^' + Regexp.escape("\#<#{ebadf.class}: #{ebadf.message}")
+            "^#{Regexp.escape("\#<#{ebadf.class}: #{ebadf.message}")}"
           end
         end
 
         def pipe_error_regex
           @pipe_error_regex ||= begin
             epipe = Errno::EPIPE.new
-            '^' + Regexp.escape("\#<#{epipe.class}: #{epipe.message}")
+            "^#{Regexp.escape("\#<#{epipe.class}: #{epipe.message}")}"
           end
         end
 
@@ -94,10 +94,11 @@ RSpec.shared_examples 'a PowerShellCodeManager' do |ps_command, ps_args|
           result = manager.execute('Write-Host "hi"')
           expect(result[:exitcode]).to eq(-1)
 
-          if reason.is_a?(String)
+          case reason
+          when String
             expect(result[:stderr][0]).to eq(reason) if style == :exact
             expect(result[:stderr][0]).to match(reason) if style == :regex
-          elsif reason.is_a?(Array)
+          when Array
             expect(reason).to include(result[:stderr][0]) if style == :exact
             if style == :regex
               expect(result[:stderr][0]).to satisfy("should match expected error(s): #{reason}") do |msg|
@@ -123,9 +124,10 @@ RSpec.shared_examples 'a PowerShellCodeManager' do |ps_command, ps_args|
         end
 
         def close_stream(stream, style = :inprocess)
-          if style == :inprocess
+          case style
+          when :inprocess
             stream.close
-          elsif style == :viahandle
+          when :viahandle
             handle = Pwsh::WindowsAPI.get_osfhandle(stream.fileno)
             Pwsh::WindowsAPI.CloseHandle(handle)
           end
@@ -212,7 +214,7 @@ RSpec.shared_examples 'a PowerShellCodeManager' do |ps_command, ps_args|
 
             # fails with vanilla EPIPE or various EBADF depening on timing / Ruby version
             msgs = [
-              '^' + Regexp.escape(Errno::EPIPE.new.inspect),
+              "^#{Regexp.escape(Errno::EPIPE.new.inspect)}",
               bad_file_descriptor_regex
             ]
             expect_dead_manager(manager, msgs, :regex)
@@ -241,7 +243,7 @@ RSpec.shared_examples 'a PowerShellCodeManager' do |ps_command, ps_args|
 
             # fails with vanilla EPIPE or various EBADF depening on timing / Ruby version
             msgs = [
-              '^' + Regexp.escape(Errno::EPIPE.new.inspect),
+              "^#{Regexp.escape(Errno::EPIPE.new.inspect)}",
               bad_file_descriptor_regex
             ]
             expect_dead_manager(manager, msgs, :regex)
@@ -295,7 +297,7 @@ RSpec.shared_examples 'a PowerShellCodeManager' do |ps_command, ps_args|
       end
 
       it 'returns the exitcode of a script invoked with the call operator &' do
-        fixture_path = File.expand_path(File.dirname(__FILE__) + '/../exit-27.ps1')
+        fixture_path = File.expand_path("#{File.dirname(__FILE__)}/../exit-27.ps1")
         result = manager.execute("& #{fixture_path}")
 
         expect(result[:stdout]).to eq(nil)
@@ -590,7 +592,7 @@ RSpec.shared_examples 'a PowerShellCodeManager' do |ps_command, ps_args|
       it 'returns a response with a timeout error if the execution timeout is exceeded' do
         timeout_ms = 100
         result = manager.execute('sleep 1', timeout_ms)
-        msg = /Catastrophic failure\: PowerShell module timeout \(#{timeout_ms} ms\) exceeded while executing/
+        msg = /Catastrophic failure: PowerShell module timeout \(#{timeout_ms} ms\) exceeded while executing/
         expect(result[:errormessage]).to match(msg)
       end
 
@@ -690,7 +692,7 @@ RSpec.shared_examples 'a PowerShellCodeManager' do |ps_command, ps_args|
           result = manager.execute(powershell_runtime_error)
 
           expect(result[:exitcode]).to eq(1)
-          expect(result[:errormessage]).to match(/At line\:\d+ char\:\d+/)
+          expect(result[:errormessage]).to match(/At line:\d+ char:\d+/)
         end
       end
 
@@ -707,7 +709,7 @@ RSpec.shared_examples 'a PowerShellCodeManager' do |ps_command, ps_args|
           result = manager.execute(powershell_parseexception_error)
 
           expect(result[:exitcode]).to eq(1)
-          expect(result[:errormessage]).to match(/At line\:\d+ char\:\d+/)
+          expect(result[:errormessage]).to match(/At line:\d+ char:\d+/)
         end
       end
 
@@ -724,7 +726,7 @@ RSpec.shared_examples 'a PowerShellCodeManager' do |ps_command, ps_args|
           result = manager.execute(powershell_incompleteparseexception_error)
 
           expect(result[:exitcode]).to eq(1)
-          expect(result[:errormessage]).not_to match(/At line\:\d+ char\:\d+/)
+          expect(result[:errormessage]).not_to match(/At line:\d+ char:\d+/)
         end
       end
     end
@@ -734,7 +736,7 @@ RSpec.shared_examples 'a PowerShellCodeManager' do |ps_command, ps_args|
         msg = SecureRandom.uuid.to_s.gsub('-', '')
         result = manager.execute("$VerbosePreference = 'Continue';Write-Verbose '#{msg}'")
 
-        expect(result[:stdout]).to match(/^VERBOSE\: #{msg}/)
+        expect(result[:stdout]).to match(/^VERBOSE: #{msg}/)
         expect(result[:exitcode]).to eq(0)
       end
 


### PR DESCRIPTION
Prior to this commit the DSC base provider would occasionally need to send an empty array as a defined property to `Invoke-DscResource`. However, the CIM instance on the other end may not be able to appropriately cast from an empty array to, say a `[String[]]` type; this would cause the run to fail. Furthermore, the provider did not have a way to distinguish between an *absent* setting and an *empty* one. Ruby does not treat empty arrays and nil as the same, even though PowerShell can/does.

This commit adds a special handler for munging the data returned from a get invocation, ensuring that if a property's value is nil AND the property was used for the query AND the resource expects an array, THEN it will set the result to the manifest value or an empty array.

It also strongly types any empty arrays being sent
to `Invoke-DscResource`, as this prevents the casting problem by making the array type casting  explicit instead of merely implicit.

- Resolves #55