### PR TITLE
(GH-57) Handle datetimes in dsc

### DIFF
--- a/lib/puppet/provider/dsc_base_provider/invoke_dsc_resource_functions.ps1
+++ b/lib/puppet/provider/dsc_base_provider/invoke_dsc_resource_functions.ps1
@@ -68,6 +68,10 @@ Function ConvertTo-CanonicalResult {
               $Value = $null
           }
       }
+      elseif ($Result.$PropertyName.GetType().Name -match 'DateTime') {
+          # Handle DateTimes especially since they're an edge case
+          $Value = Get-Date $Result.$PropertyName -UFormat "%Y-%m-%dT%H:%M:%S%Z"
+      }
       else {
           # Looks like a nested CIM instance, recurse if we're not too deep in already.
           $RecursionLevel++


### PR DESCRIPTION
Prior to this commit the dsc_base_provider could not handle DateTime objects from Puppet, having no useful way to format them for PowerShell nor read them back from a Get result.

This commit adds some minor handling to ensure that any datetimes are cast appropriately in the param hash and can be parsed by Puppet if returned.

- Fixes #57