### PR TITLE
(MAINT) Ensure parameters are canonicalized

### DIFF
--- a/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
+++ b/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
@@ -50,6 +50,8 @@ class Puppet::Provider::DscBaseProvider
           canonicalized = r.dup
           @@cached_canonicalized_resource << r.dup
         else
+          parameters = r.select{ |name,_properties| parameter_attributes(context).include?(name)}
+          canonicalized.merge!(parameters)
           canonicalized[:name] = r[:name]
           if r[:dsc_psdscrunascredential].nil?
             canonicalized.delete(:dsc_psdscrunascredential)
@@ -459,6 +461,14 @@ class Puppet::Provider::DscBaseProvider
   # @return [Array] returns an array of attribute names as symbols which are namevars
   def namevar_attributes(context)
     context.type.attributes.select { |_attribute, properties| properties[:behaviour] == :namevar }.keys
+  end
+
+  # Parses the DSC resource type definition to retrieve the names of any attributes which are specified as parameters
+  #
+  # @param context [Object] the Puppet runtime context to operate in and send feedback to
+  # @return [Array] returns an array of attribute names as symbols which are parameters
+  def parameter_attributes(context)
+    context.type.attributes.select{|name,properties| properties[:behaviour] == :parameter}.keys
   end
 
   # Look through a fully formatted string, replacing all instances where a value matches the formatted properties

--- a/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
+++ b/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
@@ -50,7 +50,7 @@ class Puppet::Provider::DscBaseProvider
           canonicalized = r.dup
           @@cached_canonicalized_resource << r.dup
         else
-          parameters = r.select{ |name,_properties| parameter_attributes(context).include?(name)}
+          parameters = r.select { |name, _properties| parameter_attributes(context).include?(name) }
           canonicalized.merge!(parameters)
           canonicalized[:name] = r[:name]
           if r[:dsc_psdscrunascredential].nil?
@@ -468,7 +468,7 @@ class Puppet::Provider::DscBaseProvider
   # @param context [Object] the Puppet runtime context to operate in and send feedback to
   # @return [Array] returns an array of attribute names as symbols which are parameters
   def parameter_attributes(context)
-    context.type.attributes.select{|name,properties| properties[:behaviour] == :parameter}.keys
+    context.type.attributes.select { |_name, properties| properties[:behaviour] == :parameter }.keys
   end
 
   # Look through a fully formatted string, replacing all instances where a value matches the formatted properties


### PR DESCRIPTION
Parameters are never returned from the get method,
which prevented them from being included in the
canonicalized resource hash passed to the set method.

This commit re-adds them to the canonicalized hash.