### PR TITLE
(GH-75) Including module name in vendored module path

### DIFF
--- a/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
+++ b/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
@@ -368,7 +368,7 @@ class Puppet::Provider::DscBaseProvider
     # This handles setting the vendored_modules_path to include the puppet module name
     # We now add the puppet module name into the path to allow multiple modules to with shared dsc_resources to be installed side by side
     # The old vendored_modules_path: puppet_x/dsc_resources
-    # The new vendored_modules_path: puppet_x/powershellget/dsc_resources
+    # The new vendored_modules_path: puppet_x/<module_name>/dsc_resources
     unless File.exist? resource[:vendored_modules_path]
       resource[:vendored_modules_path] = if root_module_path.nil?
                                            File.expand_path(Pathname.new(__FILE__).dirname + '../../../' + "puppet_x/#{puppetize_name(resource[:dscmeta_module_name])}/dsc_resources") # rubocop:disable Style/StringConcatenation


### PR DESCRIPTION
This change is required for #https://github.com/puppetlabs/Puppet.Dsc/pull/115

Currently `vendored_modules_path` is set to `puppet_x/dsc_resources` by adding this change the `vendored_modules_path` will be set to `puppet_x/<modulename>/dsc_resources`. 
This provides the capability to install PowerShell module dependencies side by side. 

This PR handlles the old method, eg `puppet_x/dsc_resources`, the new method, eg `puppet_x/<modulename>/dsc_resources` and also the case that something else happens and the `vendored_modules_path` is not set. 

Note: This PR needs to be merged before #https://github.com/puppetlabs/Puppet.Dsc/pull/115