### PR TITLE
Make root module path use puppetized module name

### DIFF
--- a/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
+++ b/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
@@ -358,7 +358,7 @@ class Puppet::Provider::DscBaseProvider
     # Because Puppet adds all of the modules to the LOAD_PATH we can be sure that the appropriate module lives here during an apply;
     # PROBLEM: This currently uses the downcased name, we need to capture the module name in the metadata I think.
     # During a Puppet agent run, the code lives in the cache so we can use the file expansion to discover the correct folder.
-    root_module_path = $LOAD_PATH.select { |path| path.match?(%r{#{resource[:dscmeta_module_name].downcase}/lib}) }.first
+    root_module_path = $LOAD_PATH.select { |path| path.match?(%r{#{puppetize_name(resource[:dscmeta_module_name])}/lib}) }.first
     resource[:vendored_modules_path] = if root_module_path.nil?
                                          File.expand_path(Pathname.new(__FILE__).dirname + '../../../' + 'puppet_x/dsc_resources') # rubocop:disable Style/StringConcatenation
                                        else


### PR DESCRIPTION
Prior to this commit the `root_module_path` in the `should_to_resource` method of the `dsc_base_provider` downcased the PowerShell module name; this would fail to discover the resources for modules like `7Zip` and `xHyper-V` which are Puppetized as `a7zip` and `xhyper_v` respectively.

This commit uses the `puppetize_name` method to ensure the PowerShell module name is appropriately munged.