### PR TITLE
(MAINT) Correctly canonicalize enumerable values in dsc

### DIFF
--- a/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
+++ b/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
@@ -61,7 +61,8 @@ class Puppet::Provider::DscBaseProvider
           downcased_result = recursively_downcase(canonicalized)
           downcased_resource = recursively_downcase(r)
           downcased_result.each do |key, value|
-            canonicalized[key] = r[key] unless downcased_resource[key] == value
+            is_same = value.is_a?(Enumerable) ? downcased_resource[key].sort == value.sort : downcased_resource[key] == value
+            canonicalized[key] = r[key] unless is_same
             canonicalized.delete(key) unless downcased_resource.keys.include?(key)
           end
           # Cache the actually canonicalized resource separately


### PR DESCRIPTION
Prior to this commit the comparison in the DSC base provider for values on the node vs values in the manifest was a simple equals check; this works for non-enumerables and for enumerables *so long as* the enumerables are in the same order.

This commit corrects the check to sort the enumerables so that the comparison is done purely on the values, not the order, as PowerShell does not care about the order of items in a hash or array.