### PR TITLE
(GH-97) Memoize class variables in initialize

### DIFF
--- a/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
+++ b/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
@@ -11,9 +11,9 @@ class Puppet::Provider::DscBaseProvider
   # - query results
   # - logon failures
   def initialize
-    @@cached_canonicalized_resource = []
-    @@cached_query_results = []
-    @@logon_failures = []
+    @@cached_canonicalized_resource ||= []
+    @@cached_query_results ||= []
+    @@logon_failures ||= []
     super
   end
 


### PR DESCRIPTION
Prior to this PR calling initialize for the dsc base provider would always set the class variables for cached_canonicalized_resource, cached_query_results, and logon_failures to empty arrays; when running with 2 or more resources of a different type, this would cause the provider to reset these values to the empty arrays, thus wiping out these caches, especially the cache for canonicalized resources, which is filled *before* the rest of the Puppet run.

This commit updates the initialize method to instead memoize those caches, only setting them to empty arrays if they do not already exist. This way, canonicalized resources from multiple types are not mysteriously removed from the cache.

- Resolves #97 