### PR TITLE
(GH-105) Ensure canonicalized_cache check validates against namevar

### DIFF
--- a/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
+++ b/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
@@ -44,7 +44,10 @@ class Puppet::Provider::DscBaseProvider
   def canonicalize(context, resources)
     canonicalized_resources = []
     resources.collect do |r|
-      if fetch_cached_hashes(@@cached_canonicalized_resource, [r]).empty?
+      # During RSAPI refresh runs mandatory parameters are stripped and not available;
+      # Instead of checking again and failing, search the cache for a namevar match.
+      namevarized_r = r.select { |k, _v| namevar_attributes(context).include?(k) }
+      if fetch_cached_hashes(@@cached_canonicalized_resource, [namevarized_r]).empty?
         canonicalized = invoke_get_method(context, r)
         if canonicalized.nil?
           canonicalized = r.dup


### PR DESCRIPTION
Prior to this commit the safety check in the canonicalize method intended to prevent multiple executions to canonicalize the same resource compared the cached resources to the *full* resource being checked; this commit changes that check to only search for a hash containing the matching namevars.

This should prevent multiple runs and bugs where mandatory parameters are dropped during an RSAPI refresh event.