### PR TITLE
(GH-105) Ensure set runs on ambiguous ensure states

### DIFF
--- a/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
+++ b/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
@@ -162,6 +162,12 @@ class Puppet::Provider::DscBaseProvider
           context.deleting(name) do
             delete(context, name_hash)
           end
+        else
+          # In this case we are not sure if the resource is being created/updated/removed
+          # as with ensure "latest" or a specific version number, so default to update.
+          context.updating(name) do
+            update(context, name_hash, should)
+          end
         end
       else
         context.updating(name) do


### PR DESCRIPTION
Prior to this commit if a resource is ensurable but the value of `ensure` on the target node was not `Present` or `Absent` the call to run `Invoke-DscResource` never gets made.

This commit updates the logic in the `set` method to call `update()` if the state of the ensurable resource is ambiguous from a CRUD perspective, which is preferable to not running set at all.