### PR TITLE
(MAINT:DO NOT MERGE) Add fallback cache check in get

### DIFF
--- a/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
+++ b/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
@@ -99,6 +99,13 @@ class Puppet::Provider::DscBaseProvider
     cached_results = fetch_cached_hashes(@@cached_query_results, names)
     return cached_results unless cached_results.empty?
 
+    # Backup validation just on name which should always be unique
+    cached_results = @@cached_query_results.select do |key, _value|
+      puppet_name = names.first.is_a?(String) ? names.first : names.first[:name]
+      key[:name] == puppet_name
+    end
+    return cached_results unless cached_results.empty?
+
     if @@cached_canonicalized_resource.empty?
       mandatory_properties = {}
     else


### PR DESCRIPTION
This commit adds a fallback check for the canonicalized cache in the get method of the dsc base provider; malformed DSC Resources which are not ensurable may be returned such that the namevar/required properties that are discovered on disk do not match the ones in the manifest; this happens because DSC does not actually always treat properties marked as required in precisely the same way Puppet treats namevars.

This commit therefore checks the canonicalized hash to see if a result for that resource was found and has a matching *Puppet* name, ignoring all other keys in the hash for the comparison.