### PR TITLE
(GH-125) Fix dsc provider canonicalization for absent resources

### DIFF
--- a/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
+++ b/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
@@ -49,27 +49,37 @@ class Puppet::Provider::DscBaseProvider
       namevarized_r = r.select { |k, _v| namevar_attributes(context).include?(k) }
       cached_result = fetch_cached_hashes(@@cached_canonicalized_resource, [namevarized_r])
       if cached_result.empty?
-        canonicalized = invoke_get_method(context, r)
-        if canonicalized.nil?
+        # If the resource is meant to be absent, skip canonicalization and rely on the manifest
+        # value; there's no reason to compare system state to desired state for casing if the
+        # resource is being removed.
+        if r[:dsc_ensure] == 'absent'
           canonicalized = r.dup
           @@cached_canonicalized_resource << r.dup
         else
-          parameters = r.select { |name, _properties| parameter_attributes(context).include?(name) }
-          canonicalized.merge!(parameters)
-          canonicalized[:name] = r[:name]
-          if r[:dsc_psdscrunascredential].nil?
-            canonicalized.delete(:dsc_psdscrunascredential)
+          canonicalized = invoke_get_method(context, r)
+          # If the resource could not be found or was returned as absent, skip case munging and
+          # treat the manifest values as canonical since the resource is being created.
+          if canonicalized.nil? || canonicalized[:dsc_ensure] == 'absent'
+            canonicalized = r.dup
+            @@cached_canonicalized_resource << r.dup
           else
-            canonicalized[:dsc_psdscrunascredential] = r[:dsc_psdscrunascredential]
+            parameters = r.select { |name, _properties| parameter_attributes(context).include?(name) }
+            canonicalized.merge!(parameters)
+            canonicalized[:name] = r[:name]
+            if r[:dsc_psdscrunascredential].nil?
+              canonicalized.delete(:dsc_psdscrunascredential)
+            else
+              canonicalized[:dsc_psdscrunascredential] = r[:dsc_psdscrunascredential]
+            end
+            downcased_result = recursively_downcase(canonicalized)
+            downcased_resource = recursively_downcase(r)
+            downcased_result.each do |key, value|
+              canonicalized[key] = r[key] unless same?(value, downcased_resource[key])
+              canonicalized.delete(key) unless downcased_resource.keys.include?(key)
+            end
+            # Cache the actually canonicalized resource separately
+            @@cached_canonicalized_resource << canonicalized.dup
           end
-          downcased_result = recursively_downcase(canonicalized)
-          downcased_resource = recursively_downcase(r)
-          downcased_result.each do |key, value|
-            canonicalized[key] = r[key] unless same?(value, downcased_resource[key])
-            canonicalized.delete(key) unless downcased_resource.keys.include?(key)
-          end
-          # Cache the actually canonicalized resource separately
-          @@cached_canonicalized_resource << canonicalized.dup
         end
       else
         canonicalized = cached_result

--- a/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
+++ b/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
@@ -59,6 +59,7 @@ class Puppet::Provider::DscBaseProvider
           canonicalized = invoke_get_method(context, r)
           # If the resource could not be found or was returned as absent, skip case munging and
           # treat the manifest values as canonical since the resource is being created.
+          # rubocop:disable Metrics/BlockNesting
           if canonicalized.nil? || canonicalized[:dsc_ensure] == 'absent'
             canonicalized = r.dup
             @@cached_canonicalized_resource << r.dup
@@ -80,6 +81,7 @@ class Puppet::Provider::DscBaseProvider
             # Cache the actually canonicalized resource separately
             @@cached_canonicalized_resource << canonicalized.dup
           end
+          # rubocop:enable Metrics/BlockNesting
         end
       else
         canonicalized = cached_result

--- a/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
+++ b/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
@@ -47,7 +47,8 @@ class Puppet::Provider::DscBaseProvider
       # During RSAPI refresh runs mandatory parameters are stripped and not available;
       # Instead of checking again and failing, search the cache for a namevar match.
       namevarized_r = r.select { |k, _v| namevar_attributes(context).include?(k) }
-      if fetch_cached_hashes(@@cached_canonicalized_resource, [namevarized_r]).empty?
+      cached_result = fetch_cached_hashes(@@cached_canonicalized_resource, [namevarized_r])
+      if cached_result.empty?
         canonicalized = invoke_get_method(context, r)
         if canonicalized.nil?
           canonicalized = r.dup
@@ -71,7 +72,7 @@ class Puppet::Provider::DscBaseProvider
           @@cached_canonicalized_resource << canonicalized.dup
         end
       else
-        canonicalized = r
+        canonicalized = cached_result
       end
       canonicalized_resources << canonicalized
     end

--- a/spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb
+++ b/spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
         end
 
         context 'when handling dsc_psdscrunascredential' do
-            let(:actual_resource) { base_resource.merge({ dsc_psdscrunascredential: nil }) }
+          let(:actual_resource) { base_resource.merge({ dsc_psdscrunascredential: nil }) }
 
           context 'when it is specified in the resource' do
             let(:manifest_resource) { base_resource.merge({ dsc_psdscrunascredential: credential_hash }) }

--- a/spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb
+++ b/spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb
@@ -16,6 +16,13 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
     }
   end
 
+  # Reset the caches after each run
+  after(:each) do
+    described_class.class_variable_set(:@@cached_canonicalized_resource, nil) # rubocop:disable Style/ClassVars
+    described_class.class_variable_set(:@@cached_query_results, nil) # rubocop:disable Style/ClassVars
+    described_class.class_variable_set(:@@logon_failures, nil) # rubocop:disable Style/ClassVars
+  end
+
   context '.initialize' do
     before(:each) do
       # Need to initialize the provider to load the class variables
@@ -91,11 +98,6 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
       allow(context).to receive(:debug)
       allow(provider).to receive(:namevar_attributes).and_return(namevar_keys)
       allow(provider).to receive(:fetch_cached_hashes).and_return(cached_canonicalized_resource)
-      described_class.class_variable_set(:@@cached_canonicalized_resource, []) # rubocop:disable Style/ClassVars
-    end
-
-    after(:all) do
-      described_class.class_variable_set(:@@cached_canonicalized_resource, []) # rubocop:disable Style/ClassVars
     end
 
     context 'when a manifest resource is in the canonicalized resource cache' do


### PR DESCRIPTION
Prior to this PR the `canonicalize` method in the DSC Base Provider did some unneccessary work:

- it _always_ called `invoke_get_method` if a resource was not already in the canonicalized cache
- it erroneously canonicalized a resource which **should** exist to values which were returned as `nil` from `invoke_get_method` because DSC returns the ensure value as `absent` and `nil` for other properties

This commit adds logic shortcuts to obviate unneccessary canonicalization of the resource when the should value for `dsc_ensure` is `absent` (because a resource being deleted does not care about casing) as well as when the should value for `dsc_ensure` is `present` but the resource itself does not actually exist on the system (a resource which is being created should treat it's own definition as canonical).

- Resolves #125 