### PR TITLE
(GH-143) Handle order insensitive arrays in the `same?` method of the DSC Base Provider

### DIFF
--- a/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
+++ b/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
@@ -527,15 +527,15 @@ class Puppet::Provider::DscBaseProvider
   # @param value2 [object] a string, array, hash, or other object to sort and compare to value1
   # @return [bool] returns equality
   def same?(value1, value2)
-    case @value1
+    case value1
     # TODO: (GH-144) Figure out a way to deeply sort hashes and arrays.
     # TODO: (GH-143) This was previously nonfunctional due to the typo above which evaluated @value1 instead
     #       of value1 (and was therefore always nil, which triggered only the else condition). If
     #       the code for Hash here is enabled, a hash without child hashes causes an error. Removing
     #       this conditional keeps prior behaviour but does not solve the root problem of hashes with
     #       the same values comparing as false if a child array is not sorted.
-    when Hash
-      !value2.nil? ? value2.sort_by { |element| element.keys.first } == value1.sort_by { |element| element.keys.first } : value2 == value1
+    # when Hash
+    #   !value2.nil? ? value2.sort_by { |element| element.keys.first } == value1.sort_by { |element| element.keys.first } : value2 == value1
     when Array
       !value2.nil? ? value2.sort == value1.sort : value2 == value1
     else

--- a/spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb
+++ b/spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb
@@ -1035,7 +1035,6 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
       expect(provider.same?({ foo: [1, 2], bar: { baz: [1, 2] } }, { foo: [2, 1], bar: { baz: [2, 1] } })).to be true
     end
     it 'compares arrays regardless of order' do
-      pending('typo in case statement causes comparisons to be unsorted')
       expect(provider.same?([1, 2], [2, 1])).to be true
     end
     it 'compares arrays with nested arrays regardless of order' do


### PR DESCRIPTION
Prior to this PR, a typo in the case statement of the `same?` method in the DSC Base Provider caused the Hash and Array cases never to run, always falling back on a simple `==` value comparison.

This caused arrays which were the same except for ordering to always fail, as `==` comparisons of arrays are order sensitive.

This PR corrects the typo, ensuring that the Array case runs. This only handles order insensitivity of arrays which have no nested values.

A future PR will be required to deeply sort arrays and hashes - see #144 for further details.

This PR also comments out the Hash case, which otherwise errors. This preserves existing behavior for Hashes, causing them to be compared with `==`, which is order insensitive for _keys_ but not for array values (this also will be resolved when #144 is implemented.

- Resolves #143