### PR TITLE
(EXPERIMENTAL) Add pdk template for rsapi-pwsh resources

### DIFF
--- a/pdk/templates/rsapi-pwsh-resource/content/lib/puppet/provider/{{pct_name}}/{{pct_name}}.rb.tmpl
+++ b/pdk/templates/rsapi-pwsh-resource/content/lib/puppet/provider/{{pct_name}}/{{pct_name}}.rb.tmpl
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'puppet/resource_api/simple_provider'
+
+# Implementation for the {{.pct_name}} type using the Resource API.
+# foo_bar
+# FooBar
+{{ $simple_provider := and .rsapi.ensurable (eq 0 (len .rsapi.features))}}
+class Puppet::Provider::{{ toClassName .pct_name}}::{{ toClassName .pct_name }}
+{{- if $simple_provider }} < Puppet::ResourceApi::SimpleProvider{{ end }}
+  def get(context)
+    context.debug('Returning pre-canned example data')
+    [
+      {
+        id: 'foo',
+        ensure: 'present',
+      },
+      {
+        id: 'bar',
+        ensure: 'present',
+      },
+    ]
+  end
+{{ if .rsapi.ensurable }}
+  def create(context, name, should)
+    context.notice("Creating '#{name}' with #{should.inspect}")
+  end
+
+  def update(context, name, should)
+    context.notice("Updating '#{name}' with #{should.inspect}")
+  end
+
+  def delete(context, name)
+    context.notice("Deleting '#{name}'")
+  end
+{{ else }}
+  def update(context, name, should)
+    context.notice("Updating '#{name}' with #{should.inspect}")
+  end
+{{ end }}
+{{ if and .rsapi.ensurable (not $simple_provider) }}
+  # Determines which method to call for a resource change (create, update, or delete),
+  # then passes the appropriate values along to the various methods which themselves
+  # Implementation borrowed directly from the Resource API Simple Provider.
+  #
+  # @param context [Object] the Puppet runtime context to operate in and send feedback to
+  # @param changes [Hash] the hash of whose key is the name_hash and value is the is and should hashes
+  def set(context, changes)
+  end
+{{ else if not $simple_provider }}
+  # stuff for calling update
+  #
+  # @param context [Object] the Puppet runtime context to operate in and send feedback to
+  # @param changes [Hash] the hash of whose key is the name_hash and value is the is and should hashes
+  def set(context, changes)
+  end
+{{ end}}
+{{ if eq .rsapi.powershell_support "powershell" }}
+  # Returns a new instance of the PowerShell manager if one does not exist or is dead,
+  # otherwise returns the existing usable instance for performance reasons.
+  def ps_manager
+    debug_output = Puppet::Util::Log.level == :debug
+    Pwsh::Manager.instance(Pwsh::Manager.powershell_path, Pwsh::Manager.powershell_args, debug: debug_output)
+  end
+{{ else if eq .rsapi.powershell_support "pwsh" }}
+  # Returns a new instance of the PowerShell manager if one does not exist or is dead,
+  # otherwise returns the existing usable instance for performance reasons.
+  def ps_manager
+    debug_output = Puppet::Util::Log.level == :debug
+    Pwsh::Manager.instance(Pwsh::Manager.pwsh_path, Pwsh::Manager.pwsh_args, debug: debug_output)
+  end
+{{ else }}
+  # Returns a new instance of the PowerShell manager if one does not exist or is dead,
+  # otherwise returns the existing usable instance for performance reasons.
+  def ps_manager(edition)
+    path = edition == 'powershell' ? Pwsh::Manager.powershell_path : Pwsh::Manager.pwsh_path
+    args = edition == 'powershell' ? Pwsh::Manager.powershell_args : Pwsh::Manager.pwsh_args
+    debug_output = Puppet::Util::Log.level == :debug
+    Pwsh::Manager.instance(path, args, debug: debug_output)
+  end
+{{ end -}}
+{{ if eq .rsapi.powershell_support "both" }}
+  # Wraps executions for the PowerShell Manager to do some basic error raising in Puppet.
+  def invoke_command(command, edition)
+    result = ps_manager(edition).execute(command)
+    raise result[:errormessage] unless result[:exitcode].zero?
+    result
+  end
+{{ else }}
+  # Wraps executions for the PowerShell Manager to do some basic error raising in Puppet.
+  def invoke_command(command)
+    result = ps_manager.execute(command)
+    raise result[:errormessage] unless result[:exitcode].zero?
+    result
+  end
+{{ end -}}
+end

--- a/pdk/templates/rsapi-pwsh-resource/content/lib/puppet/type/{{pct_name}}.rb.tmpl
+++ b/pdk/templates/rsapi-pwsh-resource/content/lib/puppet/type/{{pct_name}}.rb.tmpl
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'puppet/resource_api'
+
+Puppet::ResourceApi.register_type(
+  id: '{{.pct_name}}',
+  docs: <<~EOS
+    @summary a {{.pct_name}} type
+    @example
+    {{.pct_name}} { 'foo':
+      ensure => 'present',
+    }
+
+    This type provides Puppet with the capabilities to manage ...
+
+    If your type uses autorequires, please document as shown below, else delete
+    these lines.
+    **Autorequires**:
+    * `Package[foo]`
+  EOS
+  features: [
+{{- range $index, $feature := .rsapi.features -}}
+    {{- if $index }}, {{ end }}'{{$feature}}'
+{{- end -}}
+  ],
+  attributes: {
+{{- if .rsapi.ensurable }}
+    ensure: {
+      type: 'Enum[present, absent]',
+      desc: 'Whether this resource should be present or absent on the target system.',
+      default: 'present',
+    },
+{{- end }}
+    name: {
+      type: 'String',
+      desc: 'The name of the resource you want to manage.',
+      behaviour: :namevar,
+    },
+{{- range .rsapi.attributes }}
+    {{.name}}: {
+      type: '{{.type}}',
+      desc: '{{.desc}}',
+    },
+{{- end}}
+  },
+)

--- a/pdk/templates/rsapi-pwsh-resource/content/spec/unit/puppet/provider/{{pct_name}}_spec.rb.tmpl
+++ b/pdk/templates/rsapi-pwsh-resource/content/spec/unit/puppet/provider/{{pct_name}}_spec.rb.tmpl
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+ensure_module_defined('Puppet::Provider::{{ toClassName .pct_name }}')
+require 'puppet/provider/{{.pct_name}}/{{.pct_name}}'
+
+RSpec.describe Puppet::Provider::{{ toClassName .pct_name }}::{{ toClassName .pct_name }} do
+  subject(:provider) { described_class.new }
+
+  let(:context) { instance_double('Puppet::ResourceApi::BaseContext', 'context') }
+
+  describe '#get' do
+    it 'processes resources' do
+      expect(context).to receive(:debug).with('Returning pre-canned example data')
+      expect(provider.get(context)).to eq [
+        {
+          id: 'foo',
+          ensure: 'present',
+        },
+        {
+          id: 'bar',
+          ensure: 'present',
+        },
+      ]
+    end
+  end
+
+  describe 'create(context, name, should)' do
+    it 'creates the resource' do
+      expect(context).to receive(:notice).with(%r{\ACreating 'a'})
+
+      provider.create(context, 'a', name: 'a', ensure: 'present')
+    end
+  end
+
+  describe 'update(context, name, should)' do
+    it 'updates the resource' do
+      expect(context).to receive(:notice).with(%r{\AUpdating 'foo'})
+
+      provider.update(context, 'foo', name: 'foo', ensure: 'present')
+    end
+  end
+
+  describe 'delete(context, name)' do
+    it 'deletes the resource' do
+      expect(context).to receive(:notice).with(%r{\ADeleting 'foo'})
+
+      provider.delete(context, 'foo')
+    end
+  end
+end

--- a/pdk/templates/rsapi-pwsh-resource/content/spec/unit/puppet/type/{{pct_name}}_spec.rb.tmpl
+++ b/pdk/templates/rsapi-pwsh-resource/content/spec/unit/puppet/type/{{pct_name}}_spec.rb.tmpl
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'puppet/type/{{.pct_name}}'
+
+RSpec.describe 'the {{.pct_name}} type' do
+  it 'loads' do
+    expect(Puppet::Type.type(:{{.pct_name}})).not_to be_nil
+  end
+end

--- a/pdk/templates/rsapi-pwsh-resource/pct-config.yml
+++ b/pdk/templates/rsapi-pwsh-resource/pct-config.yml
@@ -1,0 +1,23 @@
+---
+template:
+  id: rsapi-pwsh-resource
+  type: item
+  display: Resource API Resource leveraging PowerShell
+  version: 0.1.0
+  url: https://github.com/puppetlabs/ruby-pwsh
+
+rsapi:
+  # Valid values: powershell, pwsh, both
+  powershell_support: both
+  ensurable: false
+  # This must be an empty array or replaced with the array values;
+  # not setting the features key leads to errors in template apply
+  features: []
+  # features:
+  #   - canonicalize
+  #   - custom_insync
+  #   - simple_get_filter
+  attributes:
+    - name: foo
+      type: String
+      desc: The foo of the resource you want to manage


### PR DESCRIPTION
This PR is an experiment in adding a new PDKGo (v3) template for reducing dev time/work to add a new Puppet Resource API type and provider to a Puppet module which depends on the PowerShell
manager in `ruby-pwsh`.

It currently:

- Scaffolds out type, provider, and unit test files
- allows for specification of support for powershell, pwsh, or both
- handles ensurable and non-ensurable types
- handles feature flags for the type

To Do:

- Properly handle `simple_provider` inheritance vs non-`simple_provider` resources, primarily in the scaffolded methods (`create`, `update`, and `delete` for `simple_provider` resources; `create`, `update`, `delete`, and `set` for ensurable non `simple_provider` resources; and `update`/`set` for non- ensurable resources.
- Scaffold provider unit tests for the methods as appropriate
- Handle PowerShell path/args overrides instead of only using defaults
- Consider scaffolding integration or acceptance tests
- Consider whether or not to handle fixtures and gemfile - possibly add another template for rsapi-pwsh-module with these problems solved.