### PR TITLE
(GH-147) Refactor Invocation methods to use shared helper and write error logs when appropriate

### DIFF
--- a/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
+++ b/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
@@ -111,7 +111,7 @@ class Puppet::Provider::DscBaseProvider
     # Relies on the get_simple_filter feature to pass the namevars
     # as an array containing the namevar parameters as a hash.
     # This hash is functionally the same as a should hash as
-    # passed to the should_to_resource method.
+    # passed to the invocable_resource method.
     context.debug('Collecting data from the DSC Resource')
 
     # If the resource has already been queried, do not bother querying for it again
@@ -235,7 +235,7 @@ class Puppet::Provider::DscBaseProvider
     return name_hash if !name_hash[:dsc_psdscrunascredential].nil? && logon_failed_already?(name_hash[:dsc_psdscrunascredential])
 
     query_props = name_hash.select { |k, v| mandatory_get_attributes(context).include?(k) || (k == :dsc_psdscrunascredential && !v.nil?) }
-    resource = should_to_resource(query_props, context, 'get')
+    resource = invocable_resource(query_props, context, 'get')
     script_content = ps_script_content(resource)
     context.debug("Script:\n #{redact_secrets(script_content)}")
     output = ps_manager.execute(remove_secret_identifiers(script_content))[:stdout]
@@ -324,7 +324,7 @@ class Puppet::Provider::DscBaseProvider
     return nil if !should[:dsc_psdscrunascredential].nil? && logon_failed_already?(should[:dsc_psdscrunascredential])
 
     apply_props = should.select { |k, _v| k.to_s =~ /^dsc_/ }
-    resource = should_to_resource(apply_props, context, 'set')
+    resource = invocable_resource(apply_props, context, 'set')
     script_content = ps_script_content(resource)
     context.debug("Script:\n #{redact_secrets(script_content)}")
 
@@ -348,7 +348,7 @@ class Puppet::Provider::DscBaseProvider
   # @param context [Object] the Puppet runtime context to operate in and send feedback to
   # @param dsc_invoke_method [String] the method to pass to Invoke-DscResource: get, set, or test
   # @return [Hash] a hash with the information needed to run `Invoke-DscResource`
-  def should_to_resource(should, context, dsc_invoke_method)
+  def invocable_resource(should, context, dsc_invoke_method)
     resource = {}
     resource[:parameters] = {}
     %i[name dscmeta_resource_friendly_name dscmeta_resource_name dscmeta_module_name dscmeta_module_version].each do |k|
@@ -371,7 +371,7 @@ class Puppet::Provider::DscBaseProvider
 
     resource[:attributes] = nil
 
-    context.debug("should_to_resource: #{resource.inspect}")
+    context.debug("invocable_resource: #{resource.inspect}")
     resource
   end
 
@@ -590,7 +590,7 @@ class Puppet::Provider::DscBaseProvider
     modified_string
   end
 
-  # Parses a resource definition (as from `should_to_resource`) for any properties which are PowerShell
+  # Parses a resource definition (as from `invocable_resource`) for any properties which are PowerShell
   # Credentials. As these values need to be serialized into PSCredential objects, return an array of
   # PowerShell lines, each of which instantiates a variable which holds the value as a PSCredential.
   # These credential variables can then be simply assigned in the parameter hash where needed.
@@ -624,7 +624,7 @@ class Puppet::Provider::DscBaseProvider
     "$#{variable_name} = New-PSCredential -User #{credential_hash['user']} -Password '#{credential_hash['password']}#{SECRET_POSTFIX}'"
   end
 
-  # Parses a resource definition (as from `should_to_resource`) for any properties which are CIM instances
+  # Parses a resource definition (as from `invocable_resource`) for any properties which are CIM instances
   # whether at the top level or nested inside of other CIM instances, and, where they are discovered, adds
   # those objects to the instantiated_variables hash as well as returning a line of PowerShell code which
   # will create the CIM object and store it in a variable. This then allows the CIM instances to be assigned
@@ -705,7 +705,7 @@ class Puppet::Provider::DscBaseProvider
     interpolate_variables(definition)
   end
 
-  # Munge a resource definition (as from `should_to_resource`) into valid PowerShell which represents
+  # Munge a resource definition (as from `invocable_resource`) into valid PowerShell which represents
   # the `InvokeParams` hash which will be splatted to `Invoke-DscResource`, interpolating all previously
   # defined variables into the hash.
   #
@@ -761,7 +761,7 @@ class Puppet::Provider::DscBaseProvider
     params_block
   end
 
-  # Given a resource definition (as from `should_to_resource`), return a PowerShell script which has
+  # Given a resource definition (as from `invocable_resource`), return a PowerShell script which has
   # all of the appropriate function and variable definitions, which will call Invoke-DscResource, and
   # will correct munge the results for returning to Puppet as a JSON object.
   #

--- a/spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb
+++ b/spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb
@@ -583,7 +583,6 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
 
     context 'when the DSC invocation errors' do
       it 'writes an error and returns nil' do
-        pending('Currently raises an error because the JSON parsing fails')
         expect(provider).not_to receive(:logon_failed_already?)
         expect(ps_manager).to receive(:execute).with(script).and_return({ stdout: nil })
         expect(context).to receive(:err).with('Nothing returned')
@@ -624,9 +623,8 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
 
       context 'with a previously failed logon' do
         it 'errors and returns nil if the specified account has already failed to logon' do
-          pending('Currently returns the name_hash when it should return nil; does not report error')
           expect(provider).to receive(:logon_failed_already?).and_return(true)
-          expect(context).to receive(:err)
+          expect(context).to receive(:err).with('Logon credentials are invalid')
           expect(result).to be_nil
         end
       end
@@ -655,13 +653,13 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
 
       it 'returns immediately' do
         expect(provider).to receive(:logon_failed_already?).and_return(true)
+        expect(context).to receive(:err).with('Logon credentials are invalid')
         expect(result).to eq(nil)
       end
     end
 
     context 'when the invocation script returns nil' do
       it 'errors via context but does not raise' do
-        pending('Currently raises an error because the JSON parsing fails')
         expect(ps_manager).to receive(:execute).and_return({ stdout: nil })
         expect(context).to receive(:err).with('Nothing returned')
         expect { result }.not_to raise_error
@@ -669,18 +667,18 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
     end
 
     context 'when the invocation script errors' do
-      it 'writes the error via context but does not raise and returns the results' do
+      it 'writes the error via context but does not raise and returns nil' do
         expect(ps_manager).to receive(:execute).and_return({ stdout: '{"errormessage": "DSC Error!"}' })
         expect(context).to receive(:err).with('DSC Error!')
-        expect(result).to eq({ 'errormessage' => 'DSC Error!' })
+        expect(result).to eq(nil)
       end
     end
 
     context 'when the invocation script returns data without errors' do
       it 'filters for the correct properties to invoke and returns the results' do
-        expect(ps_manager).to receive(:execute).with("Script: #{apply_props}").and_return({ stdout: '{"in_desired_state": true, "errormessage": ""}' })
+        expect(ps_manager).to receive(:execute).with("Script: #{apply_props}").and_return({ stdout: '{"in_desired_state": true, "errormessage": null}' })
         expect(context).not_to receive(:err)
-        expect(result).to eq({ 'in_desired_state' => true, 'errormessage' => '' })
+        expect(result).to eq({ 'in_desired_state' => true, 'errormessage' => nil })
       end
     end
   end

--- a/spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb
+++ b/spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb
@@ -459,7 +459,7 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
     before(:each) do
       allow(context).to receive(:debug)
       allow(provider).to receive(:mandatory_get_attributes).and_return(mandatory_get_attributes)
-      allow(provider).to receive(:should_to_resource).with(query_props, context, 'get').and_return(resource)
+      allow(provider).to receive(:invocable_resource).with(query_props, context, 'get').and_return(resource)
       allow(provider).to receive(:ps_script_content).with(resource).and_return(script)
       allow(provider).to receive(:redact_secrets).with(script)
       allow(provider).to receive(:remove_secret_identifiers).with(script).and_return(script)
@@ -644,7 +644,7 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
 
     before(:each) do
       allow(context).to receive(:debug)
-      allow(provider).to receive(:should_to_resource).with(apply_props, context, 'set').and_return(resource)
+      allow(provider).to receive(:invocable_resource).with(apply_props, context, 'set').and_return(resource)
       allow(provider).to receive(:ps_script_content).with(resource).and_return(script)
       allow(provider).to receive(:ps_manager).and_return(ps_manager)
       allow(provider).to receive(:remove_secret_identifiers).with(script).and_return(script)
@@ -699,8 +699,8 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
     end
   end
 
-  context '.should_to_resource' do
-    subject(:result) { provider.should_to_resource(should_hash, context, 'Get') }
+  context '.invocable_resource' do
+    subject(:result) { provider.invocable_resource(should_hash, context, 'Get') }
 
     let(:definition) do
       {


### PR DESCRIPTION
`should_to_resource` renamed too `invocable_resource` in order to better represent what the method does at a glance and help to ease the understanding of the module.
Logic shared between `invoke_get_method` and `invoke_set_method` has been moved into a new method, `invoke_dsc_resource`. Said logic has in turn been hardened so that it now throws an error and returns nill should any of the following occur:
- if the logon has previously failed
- if nothing is returned from the execution
- if the json cannot be parsed