### PR TITLE
(GH-141) Simplify set logic in DSC Base Provider

### DIFF
--- a/spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb
+++ b/spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb
@@ -330,27 +330,6 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
     end
   end
 
-  context '.create_absent' do
-    subject(:result) { provider.create_absent(test_namevar, test_title) }
-
-    context 'when title is a hash' do
-      let(:test_namevar) { :foo }
-      let(:test_title) { { dsc_foo: 'bar', dsc_bar: 'baz' } }
-
-      it 'duplicates the hash and sets dsc_ensure to Absent' do
-        expect(result).to eq(test_title.merge(dsc_ensure: 'Absent'))
-      end
-    end
-    context 'when title is a string' do
-      let(:test_namevar) { :dsc_foo }
-      let(:test_title) { 'bar' }
-
-      it 'duplicates the hash and sets dsc_ensure to Absent' do
-        expect(result).to eq({ dsc_foo: 'bar', dsc_ensure: 'Absent' })
-      end
-    end
-  end
-
   context '.create' do
     it 'calls invoke_set_method' do
       allow(context).to receive(:debug)


### PR DESCRIPTION
This commit cleans up and simplifies the logic in the DSC Base Provider; prior to this commit, the `set` method included handling for `nil` `is` and `should` states in the change hash; with the current implementation, neither of these values can ever be `nil` without reaching a runtime error prior to this method being called.

This commit therefore removes the complexity for handling cases where `is` or `should` are `nil` and removes the never-called method `create_absent` as it is not needed.

This commit further simplifies the `set` method by removing custom handling for retrieving the name hash as the names for Puppetized DSC Resources are always hashes and any extraneous values are stripped in `invoke_set_method` itself.

Resolves #141 