### PR TITLE
(MAINT) Refactor secrets handling in DSC

### DIFF
--- a/spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb
+++ b/spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb
@@ -1230,8 +1230,8 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
         expect(second_credential_hash).to eq({ 'user' => 'bar', 'password' => 'bar' })
       end
       it 'returns an array of strings each containing the instantiation of a PowerShell variable representing the credential hash' do
-        expect(result[0]).to match(/^\$\w+ = New-PSCredential -User foo -Password 'foo' # PuppetSensitive/)
-        expect(result[1]).to match(/^\$\w+ = New-PSCredential -User bar -Password 'bar' # PuppetSensitive/)
+        expect(result[0]).to match(/^\$\w+ = New-PSCredential -User foo -Password 'foo#PuppetSensitive'/)
+        expect(result[1]).to match(/^\$\w+ = New-PSCredential -User bar -Password 'bar#PuppetSensitive'/)
       end
     end
   end
@@ -1240,7 +1240,7 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
     let(:credential_hash) { { 'user' => 'foo', 'password' => 'bar' } }
 
     it 'returns a string representing the instantiation of a PowerShell variable representing the credential hash' do
-      expected_powershell_code = "$foo = New-PSCredential -User foo -Password 'bar' # PuppetSensitive"
+      expected_powershell_code = "$foo = New-PSCredential -User foo -Password 'bar#PuppetSensitive'"
       expect(provider.format_pscredential('foo', credential_hash)).to eq(expected_powershell_code)
     end
   end
@@ -1618,19 +1618,19 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
     let(:sensitive_complex) { "@{a = 'foo'; b = 'bar#PuppetSensitive'; c = @('a', 'b#PuppetSensitive', 'c')}" }
     let(:redacted_complex) { "@{a = 'foo'; b = '#<Sensitive [value redacted]>'; c = @('a', '#<Sensitive [value redacted]>', 'c')}" }
     let(:multiline_sensitive_string) do
-      <<~SENSITIVE
+      <<~SENSITIVE.strip
         $foo = New-PSCredential -User foo -Password 'foo#PuppetSensitive'
         $bar = New-PSCredential -User bar -Password 'bar#PuppetSensitive'
       SENSITIVE
     end
     let(:multiline_redacted_string) do
-      <<~REDACTED
+      <<~REDACTED.strip
         $foo = New-PSCredential -User foo -Password '#<Sensitive [value redacted]>'
         $bar = New-PSCredential -User bar -Password '#<Sensitive [value redacted]>'
       REDACTED
     end
     let(:multiline_sensitive_complex) do
-      <<~SENSITIVE
+      <<~SENSITIVE.strip
         @{
           a = 'foo'
           b = 'bar#PuppetSensitive'
@@ -1644,7 +1644,7 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
       SENSITIVE
     end
     let(:multiline_redacted_complex) do
-      <<~REDACTED
+      <<~REDACTED.strip
         @{
           a = 'foo'
           b = '#<Sensitive [value redacted]>'
@@ -1684,19 +1684,19 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
     let(:sensitive_complex) { "@{a = 'foo'; b = 'bar#PuppetSensitive'; c = @('a', 'b#PuppetSensitive', 'c')}" }
     let(:redacted_complex) { "@{a = 'foo'; b = 'bar'; c = @('a', 'b', 'c')}" }
     let(:multiline_sensitive_string) do
-      <<~SENSITIVE
+      <<~SENSITIVE.strip
         $foo = New-PSCredential -User foo -Password 'foo#PuppetSensitive'
         $bar = New-PSCredential -User bar -Password 'bar#PuppetSensitive'
       SENSITIVE
     end
     let(:multiline_redacted_string) do
-      <<~REDACTED
+      <<~REDACTED.strip
         $foo = New-PSCredential -User foo -Password 'foo'
         $bar = New-PSCredential -User bar -Password 'bar'
       REDACTED
     end
     let(:multiline_sensitive_complex) do
-      <<~SENSITIVE
+      <<~SENSITIVE.strip
         @{
           a = 'foo'
           b = 'bar#PuppetSensitive'
@@ -1710,7 +1710,7 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
       SENSITIVE
     end
     let(:multiline_redacted_complex) do
-      <<~REDACTED
+      <<~REDACTED.strip
         @{
           a = 'foo'
           b = 'bar'


### PR DESCRIPTION
Prior to this commit, the new handling for secrets was not utilized when preparing credentials for PowerShell. Further, the initial implementation introduced a severe performance hit when attempting to use `gsub` against a 150+ line block of text.

This commit ensures that credential secrets are handled like all other secrets. It also refactors the `redact_secrets` & `remove_secret_identifiers` methods to use a helper method, `handle_secrets`.

This new `handle_secrets` method takes an input string, replacement string, and error message as parameters. It parses the input string, first looking to see if any secrets are in it. If not, it returns the input string. Next, it breaks the input string into separate lines - the original `gsub` regex was causing noticeable performance impacts when run against the full text.

Instead, it now first naively checks to see if a line includes a secret and, if not, returns the line. If it *does* include a secret, that secret is then substituted based on the supplied replacement string from the method params.

The modified text is then rejoined with newlines and, if any secret ids remain, an error is raised instead of leaking secrets or misapplying PowerShell.

Finally, the method returns the modified text.