### PR TITLE
(GH-154) Fix canonicalization in `get` method for DSC Base Provider

### DIFF
--- a/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
+++ b/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
@@ -47,8 +47,8 @@ class Puppet::Provider::DscBaseProvider
       # During RSAPI refresh runs mandatory parameters are stripped and not available;
       # Instead of checking again and failing, search the cache for a namevar match.
       namevarized_r = r.select { |k, _v| namevar_attributes(context).include?(k) }
-      cached_result = fetch_cached_hashes(@@cached_canonicalized_resource, [namevarized_r])
-      if cached_result.empty?
+      cached_result = fetch_cached_hashes(@@cached_canonicalized_resource, [namevarized_r]).first
+      if cached_result.nil?
         # If the resource is meant to be absent, skip canonicalization and rely on the manifest
         # value; there's no reason to compare system state to desired state for casing if the
         # resource is being removed.
@@ -88,7 +88,10 @@ class Puppet::Provider::DscBaseProvider
           # rubocop:enable Metrics/BlockNesting
         end
       else
-        canonicalized = cached_result
+        # The resource has already been canonicalized for the set values and is not being canonicalized for get
+        # In this case, we do *not* want to process anything, just return the resource. We only call canonicalize
+        # so we can get case insensitive but preserving values for _setting_ state.
+        canonicalized = r
       end
       canonicalized_resources << canonicalized
     end

--- a/spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb
+++ b/spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb
@@ -74,8 +74,8 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
       let(:expected_resource) { base_resource.merge({ dsc_property: 'foobar' }) }
       let(:cached_canonicalized_resource) { expected_resource.dup }
 
-      it 'returns the cached resource' do
-        expect(canonicalized_resource).to eq([expected_resource])
+      it 'returns the manifest resource' do
+        expect(canonicalized_resource).to eq([manifest_resource])
       end
     end
 


### PR DESCRIPTION
Prior to this commit the call to `canonicalize` for a retrieved resource would return the previously cached canonical value for the specified name hash; in other words, it would return the canonicalized *should* value. The strict check for retrieved data from `get` validates that
calling `canonicalize` does *not* change the result, as it is meant to munge the manifest input into a state that matches what `get` will return.

We have been (ab?)using this functionality to force the manifest values to be case insensitive but case preserving. We do *not* want to munge the return data from the `get` method.

This commit modifies the logic for handling canonicalizing a resource hash to only munge if no entry for the namehash was found in the cache; otherwise, it returns the data as-is.

This can *only* happen when a resource has already had its should hash canonicalized during catalogue compilation and a strict check is being applied to the data returned from `get`.