### PR TITLE
(GH-154) Fix return data from `Invoke-DscResource` for empty strings and single item arrays in DSC Base Provider

### DIFF
--- a/lib/puppet/provider/dsc_base_provider/invoke_dsc_resource_functions.ps1
+++ b/lib/puppet/provider/dsc_base_provider/invoke_dsc_resource_functions.ps1
@@ -51,8 +51,10 @@ Function ConvertTo-CanonicalResult {
               $Value = 'Present'
           }
           else {
-              if ($Value -is [string] -or $value -is [string[]]) {
-                  $Value = $Value
+              if ([string]::IsNullOrEmpty($value)) {
+                  # While PowerShell can happily treat empty strings as valid for returning
+                  # an undefined enum, Puppet expects undefined values to be nil.
+                  $Value = $null
               }
 
               if ($Value.Count -eq 1 -and $Property.Definition -match '\\[\\]') {

--- a/lib/puppet/provider/dsc_base_provider/invoke_dsc_resource_functions.ps1
+++ b/lib/puppet/provider/dsc_base_provider/invoke_dsc_resource_functions.ps1
@@ -115,7 +115,7 @@ Function ConvertTo-CanonicalResult {
       }
 
       if ($Property.Definition -match 'InstanceArray') {
-          if ($Value.Count -lt 2) { $Value = @($Value) }
+          If ($Value.GetType().Name -notmatch '\[\]') { $Value = @($Value) }
       }
 
       $ResultObject.$PropertyName = $Value


### PR DESCRIPTION
Prior to this PR, the `ConvertTo-CanonicalResource` function used to munge the values `Invoke-DscResource` emits for the `Get` method into a usable hash for Puppet/Ruby to consume had minor bugs which:

1. Caused canonicalization of values for empty strings to fail against enums (because Puppet treats an empty string as an invalid enum specification whereas it treats `nil` as `undef`)
2. Caused canonicalization of values for CIM Instances which should be arrays to fail against single-item arrays (because the logic in `ConvertTo-CanonicalResult` mishandled turning single hashes into an array of hashes with a single item).

This PR corrects both issues.