### PR TITLE
(GH-154) Ensure values returned from `invoke_get_method` are recursively sorted in the DSC Base Provider to reduce canonicalization warnings.

### DIFF
--- a/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
+++ b/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
@@ -301,6 +301,9 @@ class Puppet::Provider::DscBaseProvider
     # declaration is for an absent resource and the resource is actually absent
     data.reject! { |_k, v| v.nil? } if data[:dsc_ensure] == 'Absent' && name_hash[:dsc_ensure] == 'Absent' && !name_hash_has_nil_keys
 
+    # Sort the return for order-insensitive nested enumerable comparison:
+    data = recursively_sort(data)
+
     # Cache the query to prevent a second lookup
     @@cached_query_results << data.dup if fetch_cached_hashes(@@cached_query_results, [data]).empty?
     context.debug("Returned to Puppet as #{data}")

--- a/spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb
+++ b/spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb
@@ -508,7 +508,14 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
       end
       it 'downcases keys in cim instance properties' do
         expect(result[:dsc_nestedciminstance].keys).to eq(%w[baz nestedproperty])
-        expect(result[:dsc_nestedciminstance]['nestedproperty'].keys).to eq(%w[nestedfoo nestedbar cim_instance_type])
+        expect(result[:dsc_nestedciminstance]['nestedproperty'].keys).to eq(%w[cim_instance_type nestedbar nestedfoo])
+      end
+      it 'recursively sorts the result for order-insensitive comparisons' do
+        expect(result.keys).to eq(%i[dsc_array dsc_ciminstance dsc_ensure dsc_name dsc_nestedciminstance dsc_time name])
+        expect(result[:dsc_array]).to eq(%w[bar foo])
+        expect(result[:dsc_ciminstance].keys).to eq(%w[bar foo])
+        expect(result[:dsc_nestedciminstance].keys).to eq(%w[baz nestedproperty])
+        expect(result[:dsc_nestedciminstance]['nestedproperty'].keys).to eq(%w[cim_instance_type nestedbar nestedfoo])
       end
 
       context 'when a namevar is an array' do
@@ -543,7 +550,7 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
         end
 
         it 'behaves like any other namevar when specified as not empty' do
-          expect(result[:dsc_array]).to eq(%w[foo bar])
+          expect(result[:dsc_array]).to eq(%w[bar foo])
         end
 
         context 'when the namevar array is empty' do


### PR DESCRIPTION
Prior to this PR, the values returned from DSC via `invoke_get_method` were left in the order returned by PowerShell. This caused issues during comparisons during canonicalization due to the Ruby (and therefore Puppet) caring about the ordering of arrays and hashes and PowerShell not.

This PR therefore recursively sorts the result before handing it back, ensuring that canonicalized manifest values and values returned from get are both sorted appropriately, ending the errors and mismatches.

- Resolves #154 