### PR TITLE
(MAINT) Ensure DSC does not write accidental errors

### DIFF
--- a/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
+++ b/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
@@ -252,7 +252,7 @@ class Puppet::Provider::DscBaseProvider
     context.debug("raw data received: #{data.inspect}")
 
     error = data['errormessage']
-    unless error.nil?
+    unless error.nil? || error.empty?
       # NB: We should have a way to stop processing this resource *now* without blowing up the whole Puppet run
       # Raising an error stops processing but blows things up while context.err alerts but continues to process
       if error =~ /Logon failure: the user has not been granted the requested logon type at this computer/


### PR DESCRIPTION
Prior to this commit an empty error string is treated as a failure. This commit modifies the behavior to not write an error message if the return from DSC was nil or an empty string.

This is a maintenance fix because the buggy code has not been released.