### PR TITLE
(GH-172) Enable use of class-based DSC Resources by munging PSModulePath 

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -110,7 +110,11 @@ namespace :dsc do
       File.symlink(File.dirname(__FILE__), File.expand_path('pwshlib', modules_folder))
       # Install each of the required modules for acceptance testing
       # Note: This only works for modules in the dsc namespace on the forge.
-      [{ name: 'powershellget', version: '2.2.5-0-1' }].each do |puppet_module|
+      puppetized_dsc_modules = [
+        { name: 'powershellget', version: '2.2.5-0-1' },
+        { name: 'jeadsc', version: '0.7.2-0-2' } # update to 0.7.2-0-3 on release
+      ]
+      puppetized_dsc_modules.each do |puppet_module|
         next if Dir.exist?(File.expand_path(puppet_module[:name], modules_folder))
 
         install_command = [

--- a/lib/puppet/provider/dsc_base_provider/invoke_dsc_resource_postscript.ps1
+++ b/lib/puppet/provider/dsc_base_provider/invoke_dsc_resource_postscript.ps1
@@ -3,6 +3,12 @@ Try {
 } catch {
   $Response.errormessage   = $_.Exception.Message
   return ($Response | ConvertTo-Json -Compress)
+} Finally {
+  If (![string]::IsNullOrEmpty($UnmungedPSModulePath)) {
+    # Reset the PSModulePath
+    [System.Environment]::SetEnvironmentVariable('PSModulePath', $UnmungedPSModulePath, [System.EnvironmentVariableTarget]::Machine)
+    $env:PSModulePath = [System.Environment]::GetEnvironmentVariable('PSModulePath', 'machine')
+  }
 }
 
 # keep the switch for when Test passes back changed properties

--- a/spec/acceptance/dsc/class.rb
+++ b/spec/acceptance/dsc/class.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'ruby-pwsh'
+require 'securerandom'
+
+powershell = Pwsh::Manager.instance(Pwsh::Manager.powershell_path, Pwsh::Manager.powershell_args)
+module_path = File.expand_path('../../fixtures/modules', File.dirname(__FILE__))
+# jeadsc_path = File.expand_path('jeadsc/lib/puppet_x/jeadsc/dsc_resources/JeaDsc', module_path)
+psrc_path = File.expand_path('../../fixtures/example.psrc', File.dirname(__FILE__))
+
+RSpec.describe 'DSC Acceptance: Class-Based Resource' do
+  let(:puppet_apply) do
+    "bundle exec puppet apply --modulepath #{module_path} --detailed-exitcodes --debug --trace"
+  end
+  let(:command) { "#{puppet_apply} -e \"#{manifest}\"" }
+
+  context 'Creating' do
+    let(:manifest) do
+      # This very awkward pattern is because we're not writing
+      # manifest files and need to pass them directly to puppet apply.
+      [
+        "dsc_jearolecapabilities { 'ExampleRoleCapability':",
+        "dsc_ensure      => 'Present',",
+        "dsc_path        => '#{psrc_path}',",
+        "dsc_description => 'Modified example role capability file'",
+        '}'
+      ].join(' ')
+    end
+
+    before(:all) do
+      # Commented out until we can figure out how to sensibly munge path
+      # reset_command = <<~RESET_COMMAND
+      #   $ErrorActionPreference = 'Stop'
+      #   Import-Module PowerShellGet
+      #   $ResetParameters = @{
+      #     Name = 'JeaRoleCapabilities'
+      #     ModuleName = '#{powershellget_path}'
+      #     Method = 'Set'
+      #     Property = @{
+      #       Path = '#{psrc_path}'
+      #       Ensure = 'Absent'
+      #     }
+      #   }
+      #   Invoke-DscResource @ResetParameters | ConvertTo-Json -Compress
+      # RESET_COMMAND
+      # reset_result = powershell.execute(reset_command)
+      # raise reset_result[:errormessage] unless reset_result[:errormessage].nil?
+    end
+
+    it 'applies idempotently' do
+      pending('Release of dsc-jeadsc with the dscmeta_resource_implementation key')
+      first_run_result = powershell.execute(command)
+      expect(first_run_result[:exitcode]).to be(2)
+      expect(first_run_result[:native_stdout]).to match(//)
+      expect(first_run_result[:native_stdout]).to match(/dsc_description changed  to 'Example role capability file'/)
+      expect(first_run_result[:native_stdout]).to match(/Created: Finished/)
+      expect(first_run_result[:native_stdout]).to match(/Applied catalog/)
+      second_run_result = powershell.execute(command)
+      expect(second_run_result[:exitcode]).to be(0)
+    end
+  end
+
+  context 'Updating' do
+    let(:manifest) do
+      # This very awkward pattern is because we're not writing
+      # manifest files and need to pass them directly to puppet apply.
+      [
+        "dsc_jearolecapabilities { 'ExampleRoleCapability':",
+        "dsc_ensure      => 'Present',",
+        "dsc_path        => '#{psrc_path}',",
+        "dsc_description => 'Updated'",
+        '}'
+      ].join(' ')
+    end
+
+    before(:all) do
+      # Commented out until we can figure out how to sensibly munge path
+      # reset_command = <<~RESET_COMMAND
+      #   $ErrorActionPreference = 'Stop'
+      #   Import-Module PowerShellGet
+      #   $ResetParameters = @{
+      #     Name = 'JeaRoleCapabilities'
+      #     ModuleName = '#{powershellget_path}'
+      #     Method = 'Set'
+      #     Property = @{
+      #       Path = '#{psrc_path}'
+      #       Ensure = 'Absent'
+      #     }
+      #   }
+      #   Invoke-DscResource @ResetParameters | ConvertTo-Json -Compress
+      # RESET_COMMAND
+      # reset_result = powershell.execute(reset_command)
+      # raise reset_result[:errormessage] unless reset_result[:errormessage].nil?
+    end
+
+    it 'applies idempotently' do
+      pending('Release of dsc-jeadsc with the dscmeta_resource_implementation key')
+      first_run_result = powershell.execute(command)
+      expect(first_run_result[:exitcode]).to be(2)
+      expect(first_run_result[:native_stdout]).to match(/dsc_description changed 'Example role capability file' to 'Updated'/)
+      expect(first_run_result[:native_stdout]).to match(/Updating: Finished/)
+      expect(first_run_result[:native_stdout]).to match(/Applied catalog/)
+      second_run_result = powershell.execute(command)
+      expect(second_run_result[:exitcode]).to be(0)
+    end
+  end
+
+  context 'Deleting' do
+    let(:manifest) do
+      # This very awkward pattern is because we're not writing
+      # manifest files and need to pass them directly to puppet apply.
+      [
+        "dsc_jearolecapabilities { 'ExampleRoleCapability':",
+        "dsc_ensure      => 'Absent',",
+        "dsc_path        => '#{psrc_path}'",
+        '}'
+      ].join(' ')
+    end
+
+    before(:all) do
+      # Commented out until we can figure out how to sensibly munge path
+      # reset_command = <<~RESET_COMMAND
+      #   $ErrorActionPreference = 'Stop'
+      #   Import-Module PowerShellGet
+      #   $ResetParameters = @{
+      #     Name = 'JeaRoleCapabilities'
+      #     ModuleName = '#{powershellget_path}'
+      #     Method = 'Set'
+      #     Property = @{
+      #       Path = '#{psrc_path}'
+      #       Ensure = 'Absent'
+      #     }
+      #   }
+      #   Invoke-DscResource @ResetParameters | ConvertTo-Json -Compress
+      # RESET_COMMAND
+      # reset_result = powershell.execute(reset_command)
+      # raise reset_result[:errormessage] unless reset_result[:errormessage].nil?
+    end
+
+    it 'applies idempotently' do
+      pending('Release of dsc-jeadsc with the dscmeta_resource_implementation key')
+      first_run_result = powershell.execute(command)
+      expect(first_run_result[:exitcode]).to be(2)
+      expect(first_run_result[:native_stdout]).to match(/dsc_ensure changed 'Present' to 'Absent'/)
+      expect(first_run_result[:native_stdout]).to match(/Deleting: Finished/)
+      expect(first_run_result[:native_stdout]).to match(/Applied catalog/)
+      second_run_result = powershell.execute(command)
+      expect(second_run_result[:exitcode]).to be(0)
+    end
+  end
+end


### PR DESCRIPTION
Prior to this PR, it was not possible to use the DSC Base Provider to invoke class-based DSC Resources. DSC `1.1` (the version of DSC used by Windows PowerShell `5.1`) cannot call `Invoke-DscResource` for class- based resources by module path, only by module name; further more, the module containing the DSC Resource _must_ be available in the *system* level `PSModulePath` environment variable; munging the *process* level `PSModulePath` does not work.

This PR updates the DSC Base Provider to:

1. Read the `dscmeta_resource_implementation` value from a the Puppet Resource API type definition of a resource and inject it into the invocable resource definition
2. Add the `munge_psmodulepath` method to return the PowerShell code to modify the system-level `PSModulePath` if the invocable resource is is implemented as a PowerShell class; if the resource is any other implementation it instead returns nil
3. Modify the `invoke_params` method to set the `ModuleName` key to the PowerShell module's name instead of the path to the module's manifest if the resource is implemented as a PowerShell class
4. Inject the PowerShell code from `munge_psmodulepath` into the output from the `ps_script_content` method to ensure it will be called when invoking the resource
5. Update the try/catch in the postscript code file to have a `finally` block which resets the `PSModulePath` if it was munged earlier in the invocation script, regardless of whether or not the invocation errors

## TODO:

- [x] Add acceptance tests for class-based resources
- [x] Add unit tests for `munge_psmodulepath`
- [x] All existing tests pass (update if needed)