### PR TITLE
(GH-164) Add complex DSC acceptance tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ Gemfile.lock
 
 # Acceptance Testing fixtures
 /spec/fixtures/modules/
+/spec/fixtures/test.pp
+/spec/fixtures/website/

--- a/Rakefile
+++ b/Rakefile
@@ -99,6 +99,63 @@ task :build_module do
   File.open('README.md', 'wb') { |file| file.write(actual_readme_content) }
 end
 
+# Used in vendor_dsc_module
+TAR_LONGLINK = '././@LongLink'
+
+# Vendor a Puppetized DSC Module to spec/fixtures/modules.
+#
+# This is necessary because `puppet module install` fails on modules with
+# long file paths, like xpsdesiredstateconfiguration
+#
+# @param command [String] command to execute.
+# @return [Object] the standard out stream.
+def vendor_dsc_module(name, version, destination)
+  require 'open-uri'
+  require 'rubygems/package'
+  require 'zlib'
+
+  module_uri = "https://forge.puppet.com/v3/files/dsc-#{name}-#{version}.tar.gz"
+  tar_gz_archive = File.expand_path("#{name}.tar.gz", ENV['TEMP'])
+
+  # Download the archive from the forge
+  File.open(tar_gz_archive, 'wb') do |file|
+    file.write(URI.open(module_uri).read) # rubocop:disable Security/Open
+  end
+
+  # Unzip to destination
+  # Taken directly from StackOverflow:
+  # - https://stackoverflow.com/a/19139114
+  Gem::Package::TarReader.new(Zlib::GzipReader.open(tar_gz_archive)) do |tar|
+    dest = nil
+    tar.each do |entry|
+      if entry.full_name == TAR_LONGLINK
+        dest = File.join(destination, entry.read.strip)
+        next
+      end
+      dest ||= File.join(destination, entry.full_name)
+      if entry.directory?
+        File.delete(dest) if File.file?(dest)
+        FileUtils.mkdir_p(dest, mode: entry.header.mode, verbose: false)
+      elsif entry.file?
+        FileUtils.rm_rf(dest) if File.directory?(dest)
+        File.open(dest, 'wb') do |f|
+          f.print(entry.read)
+        end
+        FileUtils.chmod(entry.header.mode, dest, verbose: false)
+      elsif entry.header.typeflag == '2' # Symlink!
+        File.symlink(entry.header.linkname, dest)
+      end
+      dest = nil
+    end
+  end
+
+  # Rename folder to just the module name, as needed by Puppet
+  Dir.glob("#{destination}/*#{name}*").each do |existing_folder|
+    new_folder = File.expand_path(name, destination)
+    FileUtils.mv(existing_folder, new_folder)
+  end
+end
+
 namespace :dsc do
   namespace :acceptance do
     desc 'Prep for running DSC acceptance tests'
@@ -107,24 +164,20 @@ namespace :dsc do
       modules_folder = File.expand_path('spec/fixtures/modules', File.dirname(__FILE__))
       FileUtils.mkdir_p(modules_folder) unless Dir.exist?(modules_folder)
       # symlink the parent folder to the modules folder for puppet
-      File.symlink(File.dirname(__FILE__), File.expand_path('pwshlib', modules_folder))
+      symlink_path = File.expand_path('pwshlib', modules_folder)
+      File.symlink(File.dirname(__FILE__), symlink_path) unless Dir.exist?(symlink_path)
       # Install each of the required modules for acceptance testing
       # Note: This only works for modules in the dsc namespace on the forge.
       puppetized_dsc_modules = [
         { name: 'powershellget', version: '2.2.5-0-1' },
-        { name: 'jeadsc', version: '0.7.2-0-2' } # update to 0.7.2-0-3 on release
+        { name: 'jeadsc', version: '0.7.2-0-2' }, # update to 0.7.2-0-3 on release
+        { name: 'xpsdesiredstateconfiguration', version: '9.1.0-0-1' },
+        { name: 'xwebadministration', version: '3.2.0-0-2' }
       ]
       puppetized_dsc_modules.each do |puppet_module|
         next if Dir.exist?(File.expand_path(puppet_module[:name], modules_folder))
 
-        install_command = [
-          'bundle exec puppet module install',
-          "dsc-#{puppet_module[:name]}",
-          "--version #{puppet_module[:version]}",
-          '--ignore-dependencies',
-          "--target-dir #{modules_folder}"
-        ].join(' ')
-        run_local_command(install_command)
+        vendor_dsc_module(puppet_module[:name], puppet_module[:version], modules_folder)
       end
     end
     RSpec::Core::RakeTask.new(:spec) do |t|

--- a/spec/acceptance/dsc/complex.rb
+++ b/spec/acceptance/dsc/complex.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'ruby-pwsh'
+
+# Needs to be declared here so it is usable in before and it blocks alike
+test_manifest = File.expand_path('../../fixtures/test.pp', File.dirname(__FILE__))
+fixtures_path = File.expand_path('../../fixtures', File.dirname(__FILE__))
+
+def execute_reset_command(command)
+  result = powershell.execute(command)
+  raise result[:errormessage] unless result[:errormessage].nil?
+end
+
+RSpec.describe 'DSC Acceptance: Complex' do
+  let(:powershell) { Pwsh::Manager.instance(Pwsh::Manager.powershell_path, Pwsh::Manager.powershell_args) }
+  let(:module_path) { File.expand_path('../../fixtures/modules', File.dirname(__FILE__)) }
+  let(:puppet_apply) do
+    "bundle exec puppet apply #{test_manifest} --modulepath #{module_path} --detailed-exitcodes --trace"
+  end
+
+  context 'Adding a new website' do
+    before(:each) do
+      reset_command = <<~RESET_COMMAND
+        # Ensure IIS is not installed
+        $Feature = Get-WindowsFeature -Name 'Web-Asp-Net45'
+        If ($Feature.Installed) {
+          Remove-WindowsFeature -Name $Feature.Name -ErrorAction Stop
+        }
+        $DefaultSite = Get-Website 'Default Web Site' -ErrorAction Continue
+        $ExampleSite = Get-Website 'Puppet DSC Site' -ErrorAction Continue
+        If ($DefaultSite.State -eq 'Stopped') {
+          Start-Website -Name $DefaultSite.Name
+        }
+        If ($ExampleSite) {
+          Stop-Website -Name $ExampleSite.Name
+          Remove-Website -Name $ExampleSite.Name
+          Remove-Item -Path '#{fixtures_path}/website' -Recurse -Force -ErrorAction SilentlyContinue
+        }
+      RESET_COMMAND
+      execute_reset_command(reset_command)
+    end
+
+    it 'applies idempotently' do
+      content = <<~MANIFEST.strip
+        $destination_path = '#{fixtures_path}/website'
+        $website_name     = 'Puppet DSC Site'
+        $site_id          = 7
+        $index_html = @(INDEXHTML)
+          <!doctype html>
+          <html lang=en>
+
+          <head>
+              <meta charset=utf-8>
+              <title>blah</title>
+          </head>
+
+          <body>
+              <p>I'm the content</p>
+          </body>
+
+          </html>
+          | INDEXHTML
+        # Install the IIS role
+        dsc_xwindowsfeature { 'IIS':
+          dsc_ensure => 'Present',
+          dsc_name   => 'Web-Server',
+        }
+
+        # Stop the default website
+        dsc_xwebsite { 'DefaultSite':
+            dsc_ensure          => 'Present',
+            dsc_name            => 'Default Web Site',
+            dsc_state           => 'Stopped',
+            dsc_serverautostart => false,
+            dsc_physicalpath    => 'C:\inetpub\wwwroot',
+            require             => Dsc_xwindowsfeature['IIS'],
+        }
+
+        # Install the ASP .NET 4.5 role
+        dsc_xwindowsfeature { 'AspNet45':
+          dsc_ensure => 'Present',
+          dsc_name   => 'Web-Asp-Net45',
+        }
+
+        file { 'WebContentFolder':
+          ensure => directory,
+          path   => $destination_path,
+          require => Dsc_xwindowsfeature['AspNet45'],
+        }
+
+        # Copy the website content
+        file { 'WebContentIndex':
+            path    => "${destination_path}/index.html",
+            content => $index_html,
+            require => File['WebContentFolder'],
+        }
+
+        # Create the new Website
+        dsc_xwebsite { 'NewWebsite':
+            dsc_ensure          => 'Present',
+            dsc_name            => $website_name,
+            dsc_siteid          => $site_id,
+            dsc_state           => 'Started',
+            dsc_serverautostart => true,
+            dsc_physicalpath    => $destination_path,
+            require             => File['WebContentIndex'],
+        }
+      MANIFEST
+      File.open(test_manifest, 'w') { |file| file.write(content) }
+      # Puppet apply the test manifest
+      first_run_result = powershell.execute(puppet_apply)
+      expect(first_run_result[:exitcode]).to be(2)
+      # The Default Site is stopped
+      expect(first_run_result[:native_stdout]).to match(%r{Dsc_xwebsite\[DefaultSite\]/dsc_state: dsc_state changed 'Started' to 'Stopped'})
+      expect(first_run_result[:native_stdout]).to match(/dsc_xwebsite\[{:name=>"DefaultSite", :dsc_name=>"Default Web Site"}\]: Updating: Finished/)
+      # AspNet45 is installed
+      expect(first_run_result[:native_stdout]).to match(%r{Dsc_xwindowsfeature\[AspNet45\]/dsc_ensure: dsc_ensure changed 'Absent' to 'Present'})
+      expect(first_run_result[:native_stdout]).to match(/dsc_xwindowsfeature\[{:name=>"AspNet45", :dsc_name=>"Web-Asp-Net45"}\]: Creating: Finished/)
+      # Web content folder created
+      expect(first_run_result[:native_stdout]).to match(%r{File\[WebContentFolder\]/ensure: created})
+      # Web content index created
+      expect(first_run_result[:native_stdout]).to match(%r{File\[WebContentIndex\]/ensure: defined content as '.+'})
+      # Web site created
+      expect(first_run_result[:native_stdout]).to match(%r{Dsc_xwebsite\[NewWebsite\]/dsc_siteid: dsc_siteid changed  to 7})
+      expect(first_run_result[:native_stdout]).to match(%r{Dsc_xwebsite\[NewWebsite\]/dsc_ensure: dsc_ensure changed 'Absent' to 'Present'})
+      expect(first_run_result[:native_stdout]).to match(%r{Dsc_xwebsite\[NewWebsite\]/dsc_physicalpath: dsc_physicalpath changed  to '.+fixtures/website'})
+      expect(first_run_result[:native_stdout]).to match(%r{Dsc_xwebsite\[NewWebsite\]/dsc_state: dsc_state changed  to 'Started'})
+      expect(first_run_result[:native_stdout]).to match(%r{Dsc_xwebsite\[NewWebsite\]/dsc_serverautostart: dsc_serverautostart changed  to 'true'})
+      expect(first_run_result[:native_stdout]).to match(/dsc_xwebsite\[{:name=>"NewWebsite", :dsc_name=>"Puppet DSC Site"}\]: Creating: Finished/)
+      # Run finished
+      expect(first_run_result[:native_stdout]).to match(/Applied catalog/)
+      # Second run is idempotent
+      second_run_result = powershell.execute(puppet_apply)
+      expect(second_run_result[:exitcode]).to be(0)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds acceptance tests for the DSC Base Provider which:

1. Validates the interoperation of Puppet resources and DSC resources
2. Validates the use of the same DSC Resource type to manage two
   resources simultaneously
3. Validates the use of different DSC Resources in the same Puppet run
4. Validates the use of DSC Resources with metaparameters

- resolves #164 