### PR TITLE
(GH-180) Ensure instance_key respects full uniqueness of options

### DIFF
--- a/lib/pwsh.rb
+++ b/lib/pwsh.rb
@@ -406,7 +406,7 @@ Invoke-PowerShellUserCode @params
     #
     # @return[String] Unique string representing the manager instance.
     def self.instance_key(cmd, args, options)
-      cmd + args.join(' ') + options[:debug].to_s
+      cmd + args.join(' ') + options.to_s
     end
 
     # Return whether or not a particular stream is valid and readable

--- a/spec/unit/pwsh_spec.rb
+++ b/spec/unit/pwsh_spec.rb
@@ -44,7 +44,7 @@ RSpec.shared_examples 'a PowerShellCodeManager' do |ps_command, ps_args|
 
     describe 'when managing the powershell process' do
       describe 'the Manager::instance method' do
-        it 'returns the same manager instance / process given the same cmd line' do
+        it 'returns the same manager instance / process given the same cmd line and options' do
           first_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
 
           manager_two = Pwsh::Manager.instance(ps_command, ps_args)
@@ -52,6 +52,16 @@ RSpec.shared_examples 'a PowerShellCodeManager' do |ps_command, ps_args|
 
           expect(manager_two).to eq(manager)
           expect(first_pid).to eq(second_pid)
+        end
+
+        it 'returns different manager instances / processes given the same cmd line and different options' do
+          first_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
+
+          manager_two = Pwsh::Manager.instance(ps_command, ps_args, { some_option: 'foo' })
+          second_pid = manager_two.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
+
+          expect(manager_two).not_to eq(manager)
+          expect(first_pid).not_to eq(second_pid)
         end
 
         it 'fails if the manger is created with a short timeout' do


### PR DESCRIPTION
Prior to this commit, the instance_key method for the PowerShell Manager only partially
respected the uniqueness of a possible instance; if there are any differences between
two declarations in the path to the executable, arguments passed to the executable, or
the debug option, the manager would treat the new instance as expected, spinning up an
additional instance of the manager.

However, it completely ignored the pipe_timeout option, meaning specifying an instance
with a default pipe_timeout and a second instance with a pipe_timeout of 45 would
**actually** result in the second instance declaration just reusing the existing instance
with the default timeout, which is unwanted an unexpected behavior.

This commit modifies the logic for the instance_key method slightly by making the key a
concatenation of the path to the executable, the arguments, and the full options hash
turned into a string.

This both ensures that instance declarations with two different pipe timeouts are actually
both spun up as separate instances *and* enables a workaround for multi-threading:

Users will be able to specify an arbitrary option, such as instance_guid, which can uniquely
identify the instance for that thread. This should help folks keep the instances separated
and prevent weird behavior when calling the manager from multiple threads (though, of course,
this does mean that the multi-threading still has a spinup cost for each thread).

Related to/discovered in #180.