### PR TITLE
(MODULES-11343) Preserve metaparameters

### DIFF
--- a/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
+++ b/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
@@ -79,6 +79,9 @@ class Puppet::Provider::DscBaseProvider
             end
             downcased_result = recursively_downcase(canonicalized)
             downcased_resource = recursively_downcase(r)
+            # Ensure that metaparameters are preserved when we canonicalize the resource.
+            metaparams = downcased_resource.select { |key, _value| Puppet::Type.metaparam?(key) }
+            canonicalized.merge!(metaparams) unless metaparams.nil?
             downcased_result.each do |key, value|
               # Canonicalize to the manifest value unless the downcased strings match and the attribute is not an enum:
               # - When the values don't match at all, the manifest value is desired;

--- a/spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb
+++ b/spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb
@@ -82,6 +82,16 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
       allow(provider).to receive(:fetch_cached_hashes).and_return(cached_canonicalized_resource)
     end
 
+    context 'when a manifest resource has meta parameters' do
+      let(:manifest_resource) { base_resource.merge({ dsc_ensure: 'present', noop: true }) }
+      let(:expected_resource) { base_resource.merge({ dsc_property: 'foobar' }) }
+      let(:cached_canonicalized_resource) { expected_resource.dup }
+
+      it 'does not get removed as part of the canonicalization' do
+        expect(canonicalized_resource.first[:noop]).to eq(true)
+      end
+    end
+
     context 'when a manifest resource is in the canonicalized resource cache' do
       let(:manifest_resource) { base_resource.merge({ dsc_property: 'FooBar' }) }
       let(:expected_resource) { base_resource.merge({ dsc_property: 'foobar' }) }


### PR DESCRIPTION
Prior to this PR metaparameters were not preserved during the initial canonicalization of a resource.

This PR ensures that canonicalization preserves any metaparameters that may be present in a given resource.