### PR TITLE
(CAT-1172) - Add Puppet 8 Support/Drop Puppet 6 Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           - ruby_version: '2.7'
             puppet_version: '~> 7.0'
           - ruby_version: '3.2'
-            puppet_version: 'https://github.com/puppetlabs/puppet'
+            puppet_version: '~> 8.0'
     name: "spec (ruby ${{ matrix.ruby_version }} | puppet ${{ matrix.puppet_version }})"
     uses: "puppetlabs/cat-github-actions/.github/workflows/gem_ci.yml@main"
     secrets: "inherit"
@@ -37,7 +37,7 @@ jobs:
           - ruby-version: '2.7'
             puppet_version: '~> 7.0'
           - ruby_version: '3.2'
-            puppet_version: 'https://github.com/puppetlabs/puppet' # puppet8'
+            puppet_version: '~> 8.0'
         runs_on:
           - "windows-latest"
     name: "acceptance (${{ matrix.runs_on}} ruby ${{ matrix.ruby_version }} | puppet ${{ matrix.puppet_version }})"

--- a/.github/workflows/custom_acceptance.yml
+++ b/.github/workflows/custom_acceptance.yml
@@ -18,7 +18,7 @@ on:
       puppet_version:
         description: "The target Puppet version."
         required: false
-        default: "puppet7-nightly"
+        default: "puppet8"
         type: "string"
       rake_task:
         description: "The name of the rake task that executes acceptance tests"
@@ -36,9 +36,6 @@ jobs:
     name: "acceptance"
     runs-on: ${{ inputs.runs_on }}
 
-    env:
-      PUPPET_GEM_VERSION: ${{ inputs.puppet_version }}
-
     steps:
 
       - name: "checkout"
@@ -46,7 +43,7 @@ jobs:
 
       - name: "export environment"
         run: |
-          echo "PUPPET_GEM_VERSION=${{ inputs.puppet_gem_version }} >> $GITHUB_ENV"
+          echo "PUPPET_GEM_VERSION=${{ inputs.puppet_version }} >> $GITHUB_ENV"
 
       - name: "setup ruby"
         uses: "ruby/setup-ruby@v1"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,7 +17,7 @@ jobs:
           - ruby_version: '2.7'
             puppet_version: '~> 7.0'
           - ruby_version: '3.2'
-            puppet_version: 'https://github.com/puppetlabs/puppet'
+            puppet_version: '~> 8.0'
     name: "spec (ruby ${{ matrix.ruby_version }} | puppet ${{ matrix.puppet_version }})"
     uses: "puppetlabs/cat-github-actions/.github/workflows/gem_ci.yml@main"
     secrets: "inherit"
@@ -36,7 +36,7 @@ jobs:
           - ruby-version: '2.7'
             puppet_version: '~> 7.0'
           - ruby_version: '3.2'
-            puppet_version: 'https://github.com/puppetlabs/puppet' # puppet8'
+            puppet_version: '~> 8.0'
         runs_on:
           - "windows-latest"
     name: "acceptance (${{ matrix.runs_on}} ruby ${{ matrix.ruby_version }} | puppet ${{ matrix.puppet_version }})"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,3 +14,26 @@ jobs:
     with:
       target: "${{ github.event.inputs.target }}"
     secrets: "inherit"
+  
+  module_release:
+    needs: gem_release
+    runs-on: "ubuntu-latest"
+
+    steps:
+
+      - name: "Checkout"
+        uses: "actions/checkout@v3"
+        with:
+          ref: "${{ github.ref }}"
+          clean: true
+          fetch-depth: 0
+
+      - name: "PDK build"
+        uses: "docker://puppet/pdk:3.0.0.0"
+        with:
+          args: "build"
+
+      - name: "Publish module"
+        uses: "docker://puppet/pdk:3.0.0.0"
+        with:
+          args: 'release publish --forge-token ${{ secrets.FORGE_API_KEY }} --force'

--- a/.github/workflows/release_prep.yml
+++ b/.github/workflows/release_prep.yml
@@ -18,3 +18,49 @@ jobs:
       target: "${{ github.event.inputs.target }}"
       version: "${{ github.event.inputs.version }}"
     secrets: "inherit"
+
+  module_release_prep:
+    needs: gem_release_prep
+    runs-on: "ubuntu-latest"
+
+    steps:
+
+      - name: "Checkout"
+        uses: "actions/checkout@v3"
+        with:
+          fetch-depth: 0
+
+      - name: "Update metadata.json"
+        run: |
+          current_version=$(jq --raw-output .version metadata.json)
+          # Update version in metadata.json, only matching first occurrence
+          sed -i "0,/$current_version/s//${{ github.event.inputs.version }}/" $(find . -name 'metadata.json')
+
+      - name: "Get version"
+        id: "get_version"
+        run: |
+          echo "version=$(jq --raw-output .version metadata.json)" >> $GITHUB_OUTPUT
+
+      - name: "Commit changes"
+        run: |
+          git config --local user.email "${{ github.repository_owner }}@users.noreply.github.com"
+          git config --local user.name "GitHub Actions"
+          git add .
+          git commit -m "Module Release prep v${{ steps.get_version.outputs.version }}"
+
+      - name: "Create pull Request"
+        uses: "peter-evans/create-pull-request@v5"
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "Module Release prep v${{ steps.get_version.outputs.version }}"
+          branch: "release-prep"
+          delete-branch: true
+          title: "Release prep v${{ steps.get_version.outputs.version }}"
+          base: "main"
+          body: |
+            Automated release-prep through [pdk-templates](https://github.com/puppetlabs/pdk-templates/blob/main/moduleroot/.github/workflows/auto_release.yml.erb) from commit ${{ github.sha }}.
+            Please verify before merging:
+            - [ ] last [nightly](https://github.com/${{ github.repository }}/actions/workflows/nightly.yml) run is green
+            - [ ] [Changelog](https://github.com/${{ github.repository }}/blob/release-prep/CHANGELOG.md) is readable and has no unlabeled pull requests
+            - [ ] Ensure the [changelog](https://github.com/${{ github.repository }}/blob/release-prep/CHANGELOG.md) version and [metadata](https://github.com/${{ github.repository }}/blob/release-prep/metadata.json) version match
+          labels: "maintenance"

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -22,37 +22,11 @@ Gemspec/RequiredRubyVersion:
     - 'ruby-pwsh.gemspec'
 
 # Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-# Layout/HeredocIndentation:
-#   Exclude:
-#     - 'lib/pwsh.rb'
-#
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle, IndentationWidth.
-# SupportedStyles: aligned, indented
-# Layout/LineEndStringConcatenationIndentation:
-#   Exclude:
-#     - 'ruby-pwsh.gemspec'
-#
-# Offense count: 2
-# This cop supports safe autocorrection (--autocorrect).
-# Lint/AmbiguousOperatorPrecedence:
-#   Exclude:
-#     - 'spec/unit/pwsh_spec.rb'
-#
-# Offense count: 1
 # Configuration parameters: IgnoreLiteralBranches, IgnoreConstantBranches.
 Lint/DuplicateBranch:
   Exclude:
     - 'lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb'
 
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-# Lint/DuplicateMagicComment:
-#   Exclude:
-#     - 'spec/acceptance/dsc/cim_instances.rb'
-#
 # Offense count: 1
 # Configuration parameters: AllowComments.
 Lint/EmptyClass:
@@ -105,103 +79,16 @@ Naming/FileName:
     - 'lib/ruby-pwsh.rb'
 
 # Offense count: 1
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Performance/Casecmp:
-#   Exclude:
-#     - 'lib/pwsh.rb'
-#
-# Offense count: 1
 # Configuration parameters: MinSize.
 Performance/CollectionLiteralInLoop:
   Exclude:
     - 'lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb'
 
-# Offense count: 1
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Performance/Count:
-#   Exclude:
-#     - 'lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb'
-#
-# Offense count: 1
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Performance/Detect:
-#   Exclude:
-#     - 'lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb'
-#
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: IncludeActiveSupportAliases.
-# Performance/DoubleStartEndWith:
-#   Exclude:
-#     - 'spec/unit/pwsh_spec.rb'
-#
-# Offense count: 3
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Performance/InefficientHashSearch:
-#   Exclude:
-#     - 'lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb'
-#
-# Offense count: 2
-# This cop supports safe autocorrection (--autocorrect).
-# Performance/RedundantMatch:
-#   Exclude:
-#     - 'lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb'
-#
-# Offense count: 1
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: MaxKeyValuePairs.
-# Performance/RedundantMerge:
-#   Exclude:
-#     - 'lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb'
-#
-# Offense count: 8
-# This cop supports safe autocorrection (--autocorrect).
-# Performance/RegexpMatch:
-#   Exclude:
-#     - 'bin/metadata-json-lint'
-#     - 'bin/rubocop'
-#     - 'lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb'
-#
-# Offense count: 7
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Performance/StringInclude:
-#   Exclude:
-#     - 'bin/metadata-json-lint'
-#     - 'bin/rubocop'
-#     - 'lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb'
-#     - 'spec/unit/pwsh_spec.rb'
-#
-# Offense count: 8
-# This cop supports safe autocorrection (--autocorrect).
-# Performance/StringReplacement:
-#   Exclude:
-#     - 'lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb'
-#     - 'lib/pwsh.rb'
-#     - 'spec/unit/pwsh_spec.rb'
-#
 # Offense count: 11
 RSpec/AnyInstance:
   Exclude:
     - 'spec/unit/pwsh/windows_powershell_spec.rb'
 
-# Offense count: 45
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# RSpec/BeEq:
-#   Exclude:
-#     - 'spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb'
-#     - 'spec/unit/pwsh/windows_powershell_spec.rb'
-#     - 'spec/unit/pwsh_spec.rb'
-#
-# Offense count: 7
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: be, be_nil
-# RSpec/BeNil:
-#   Exclude:
-#     - 'spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb'
-#     - 'spec/unit/pwsh/version_spec.rb'
-#     - 'spec/unit/pwsh_spec.rb'
-#
 # Offense count: 5
 RSpec/BeforeAfterAll:
   Exclude:
@@ -210,21 +97,6 @@ RSpec/BeforeAfterAll:
     - 'spec/support/**/*.rb'
     - 'spec/acceptance/dsc/basic.rb'
 
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: be_a, be_kind_of
-# RSpec/ClassCheck:
-#   Exclude:
-#     - 'spec/unit/pwsh/version_spec.rb'
-#
-# Offense count: 55
-# This cop supports safe autocorrection (--autocorrect).
-# RSpec/ContextMethod:
-#   Exclude:
-#     - 'spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb'
-#     - 'spec/unit/pwsh/util_spec.rb'
-#
 # Offense count: 81
 # Configuration parameters: Prefixes, AllowedPatterns.
 # Prefixes: when, with, without
@@ -254,66 +126,11 @@ RSpec/DescribeClass:
     - 'spec/acceptance/dsc/complex.rb'
     - 'spec/unit/pwsh_spec.rb'
 
-# Offense count: 4
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: SkipBlocks, EnforcedStyle.
-# SupportedStyles: described_class, explicit
-# RSpec/DescribedClass:
-#   Exclude:
-#     - 'spec/unit/pwsh_spec.rb'
-#
-# Offense count: 59
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: AllowConsecutiveOneLiners.
-# RSpec/EmptyLineAfterExample:
-#   Exclude:
-#     - 'spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb'
-#     - 'spec/unit/pwsh/util_spec.rb'
-#     - 'spec/unit/pwsh/windows_powershell_spec.rb'
-#
-# Offense count: 9
-# This cop supports safe autocorrection (--autocorrect).
-# RSpec/EmptyLineAfterExampleGroup:
-#   Exclude:
-#     - 'spec/acceptance/dsc/basic.rb'
-#     - 'spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb'
-#     - 'spec/unit/pwsh/windows_powershell_spec.rb'
-#
-# Offense count: 3
-# This cop supports safe autocorrection (--autocorrect).
-# RSpec/EmptyLineAfterFinalLet:
-#   Exclude:
-#     - 'spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb'
-#     - 'spec/unit/pwsh/util_spec.rb'
-#     - 'spec/unit/pwsh_spec.rb'
-#
-# Offense count: 3
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: AllowConsecutiveOneLiners.
-# RSpec/EmptyLineAfterHook:
-#   Exclude:
-#     - 'spec/acceptance/dsc/basic.rb'
-#     - 'spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb'
-#
 # Offense count: 31
 # Configuration parameters: CountAsOne.
 RSpec/ExampleLength:
   Max: 70
 
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: CustomTransform, IgnoredWords, DisallowedExamples.
-# DisallowedExamples: works
-# RSpec/ExampleWording:
-#   Exclude:
-#     - 'spec/unit/pwsh_spec.rb'
-#
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-# RSpec/ExcessiveDocstringSpacing:
-#   Exclude:
-#     - 'spec/unit/pwsh/windows_powershell_spec.rb'
-#
 # Offense count: 7
 # Configuration parameters: Include, CustomTransform, IgnoreMethods, SpecSuffixOnly.
 # Include: **/*_spec*rb*, **/spec/**/*
@@ -327,43 +144,6 @@ RSpec/FilePath:
     - 'spec/unit/pwsh/version_spec.rb'
     - 'spec/unit/pwsh/windows_powershell_spec.rb'
 
-# Offense count: 38
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: .
-# SupportedStyles: implicit, each, example
-# RSpec/HookArgument:
-#   EnforcedStyle: each
-#
-# Offense count: 2
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: .
-# SupportedStyles: is_expected, should
-# RSpec/ImplicitExpect:
-#   EnforcedStyle: should
-#
-# Offense count: 2
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: single_line_only, single_statement_only, disallow, require_implicit
-# RSpec/ImplicitSubject:
-#   Exclude:
-#     - 'spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb'
-#
-# Offense count: 2
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: it_behaves_like, it_should_behave_like
-# RSpec/ItBehavesLike:
-#   Exclude:
-#     - 'spec/unit/pwsh_spec.rb'
-#
-# Offense count: 13
-# This cop supports safe autocorrection (--autocorrect).
-# RSpec/LetBeforeExamples:
-#   Exclude:
-#     - 'spec/unit/pwsh/util_spec.rb'
-#     - 'spec/unit/pwsh_spec.rb'
-#
 # Offense count: 102
 # Configuration parameters: .
 # SupportedStyles: have_received, receive
@@ -397,21 +177,6 @@ RSpec/NoExpectationExample:
     - 'spec/unit/pwsh/windows_powershell_spec.rb'
     - 'spec/unit/pwsh_spec.rb'
 
-# Offense count: 5
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: not_to, to_not
-# RSpec/NotToNot:
-#   Exclude:
-#     - 'spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb'
-#     - 'spec/unit/pwsh_spec.rb'
-#
-# Offense count: 3
-# This cop supports safe autocorrection (--autocorrect).
-# RSpec/ScatteredLet:
-#   Exclude:
-#     - 'spec/unit/pwsh_spec.rb'
-#
 # Offense count: 55
 RSpec/StubbedMock:
   Exclude:
@@ -424,24 +189,11 @@ RSpec/SubjectStub:
   Exclude:
     - 'spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb'
 
-# Offense count: 15
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: .
-# SupportedStyles: constant, string
-# RSpec/VerifiedDoubleReference:
-#   EnforcedStyle: string
-#
 # Offense count: 6
 Style/ClassVars:
   Exclude:
     - 'lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb'
 
-# Offense count: 2
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Style/CollectionCompact:
-#   Exclude:
-#     - 'lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb'
-#
 # Offense count: 1
 # Configuration parameters: AllowedConstants.
 Style/Documentation:
@@ -450,67 +202,6 @@ Style/Documentation:
     - 'test/**/*'
     - 'lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb'
 
-# Offense count: 2
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Style/EnvHome:
-#   Exclude:
-#     - 'spec/unit/pwsh_spec.rb'
-#
-# Offense count: 3
-# This cop supports safe autocorrection (--autocorrect).
-# Style/ExpandPathArguments:
-#   Exclude:
-#     - 'lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb'
-#     - 'lib/pwsh.rb'
-#     - 'spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb'
-#
-# Offense count: 14
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: AllowedVars.
-# Style/FetchEnvVar:
-#   Exclude:
-#     - 'lib/pwsh.rb'
-#     - 'spec/unit/pwsh_spec.rb'
-#
-# Offense count: 2
-# This cop supports safe autocorrection (--autocorrect).
-# Style/FileWrite:
-#   Exclude:
-#     - 'spec/acceptance/dsc/cim_instances.rb'
-#     - 'spec/acceptance/dsc/complex.rb'
-#
-# Offense count: 2
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: Methods.
-# Style/RedundantArgument:
-#   Exclude:
-#     - 'lib/pwsh.rb'
-#
-# Offense count: 5
-# This cop supports safe autocorrection (--autocorrect).
-# Style/RedundantStringEscape:
-#   Exclude:
-#     - 'spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb'
-#     - 'spec/unit/pwsh/util_spec.rb'
-#     - 'spec/unit/pwsh_spec.rb'
-#
-# Offense count: 9
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: implicit, explicit
-# Style/RescueStandardError:
-#   Exclude:
-#     - 'lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb'
-#     - 'lib/pwsh.rb'
-#     - 'lib/pwsh/windows_powershell.rb'
-#     - 'spec/unit/pwsh_spec.rb'
-#
-# Offense count: 1
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Style/SelectByRegexp:
-#   Exclude:
-#     - 'lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb'
-#
 # Offense count: 121
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, AllowedPatterns.

--- a/metadata.json
+++ b/metadata.json
@@ -73,7 +73,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.0.0 < 8.0.0"
+      "version_requirement": ">= 7.0.0 < 9.0.0"
     }
   ],
   "pdk-version": "3.0.0",


### PR DESCRIPTION
## Summary
This PR Adds support for Puppet 8.
It also drops support for Puppet 6.

## Additional Context
Most work already completed in https://github.com/puppetlabs/ruby-pwsh/pull/208

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
