### PR TITLE
(bug) - Fixes missing mandatory ID

### DIFF
--- a/spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb
+++ b/spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'puppet/resource_api'
 require 'puppet/type'
 require 'puppet/provider/dsc_base_provider/dsc_base_provider'
 require 'json'
@@ -16,40 +15,40 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
 
   # Reset the caches after each run
   after do
-    described_class.class_variable_set(:@@cached_canonicalized_resource, nil) # rubocop:disable Style/ClassVars
-    described_class.class_variable_set(:@@cached_query_results, nil) # rubocop:disable Style/ClassVars
-    described_class.class_variable_set(:@@cached_test_results, nil) # rubocop:disable Style/ClassVars
-    described_class.class_variable_set(:@@logon_failures, nil) # rubocop:disable Style/ClassVars
+    described_class.instance_variable_set(:@cached_canonicalized_resource, [])
+    described_class.instance_variable_set(:@cached_query_results, [])
+    described_class.instance_variable_set(:@cached_test_results, [])
+    described_class.instance_variable_set(:@logon_failures, [])
   end
 
   describe '.initialize' do
     before do
-      # Need to initialize the provider to load the class variables
+      # Need to initialize the provider to load the instance variables
       provider
     end
 
-    it 'initializes the cached_canonicalized_resource class variable' do
-      expect(described_class.class_variable_get(:@@cached_canonicalized_resource)).to eq([])
+    it 'initializes the cached_canonicalized_resource instance variable' do
+      expect(described_class.instance_variable_get(:@cached_canonicalized_resource)).to eq([])
     end
 
-    it 'initializes the cached_query_results class variable' do
-      expect(described_class.class_variable_get(:@@cached_query_results)).to eq([])
+    it 'initializes the cached_query_results instance variable' do
+      expect(described_class.instance_variable_get(:@cached_query_results)).to eq([])
     end
 
-    it 'initializes the cached_test_results class variable' do
-      expect(described_class.class_variable_get(:@@cached_test_results)).to eq([])
+    it 'initializes the cached_test_results instance variable' do
+      expect(described_class.instance_variable_get(:@cached_test_results)).to eq([])
     end
 
-    it 'initializes the logon_failures class variable' do
-      expect(described_class.class_variable_get(:@@logon_failures)).to eq([])
+    it 'initializes the logon_failures instance variable' do
+      expect(described_class.instance_variable_get(:@logon_failures)).to eq([])
     end
   end
 
   describe '.cached_test_results' do
     let(:cache_value) { %w[foo bar] }
 
-    it 'returns the value of the @@cached_test_results class variable' do
-      described_class.class_variable_set(:@@cached_test_results, cache_value) # rubocop:disable Style/ClassVars
+    it 'returns the value of the @cached_test_results instance variable' do
+      described_class.instance_variable_set(:@cached_test_results, cache_value)
       expect(provider.cached_test_results).to eq(cache_value)
     end
   end
@@ -238,11 +237,11 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
 
   describe '.get' do
     after do
-      described_class.class_variable_set(:@@cached_canonicalized_resource, []) # rubocop:disable Style/ClassVars
+      described_class.instance_variable_set(:@cached_canonicalized_resource, [])
     end
 
     it 'checks the cached results, returning if one exists for the specified names' do
-      described_class.class_variable_set(:@@cached_canonicalized_resource, []) # rubocop:disable Style/ClassVars
+      described_class.instance_variable_set(:@cached_canonicalized_resource, [])
       allow(context).to receive(:debug)
       expect(provider).to receive(:fetch_cached_hashes).with([], [{ name: 'foo' }]).and_return([{ name: 'foo', property: 'bar' }])
       expect(provider).not_to receive(:invoke_get_method)
@@ -250,7 +249,7 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
     end
 
     it 'adds mandatory properties to the name hash when calling invoke_get_method' do
-      described_class.class_variable_set(:@@cached_canonicalized_resource, [{ name: 'foo', property: 'bar', dsc_some_parameter: 'baz' }]) # rubocop:disable Style/ClassVars
+      described_class.instance_variable_set(:@cached_canonicalized_resource, [{ name: 'foo', property: 'bar', dsc_some_parameter: 'baz' }])
       allow(context).to receive(:debug)
       expect(provider).to receive(:fetch_cached_hashes).with([], [{ name: 'foo' }]).and_return([])
       expect(provider).to receive(:namevar_attributes).and_return([:name]).exactly(3).times
@@ -531,7 +530,7 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
     end
 
     after do
-      described_class.class_variable_set(:@@cached_query_results, nil) # rubocop:disable Style/ClassVars
+      described_class.instance_variable_set(:@cached_query_results, nil)
     end
 
     context 'when the invocation script returns data without errors' do
@@ -558,7 +557,7 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
 
       it 'caches the result' do
         expect { result }.not_to raise_error
-        expect(described_class.class_variable_get(:@@cached_query_results)).to eq([result])
+        expect(described_class.instance_variable_get(:@cached_query_results)).to eq([result])
       end
 
       it 'removes unrelated properties from the result' do
@@ -720,7 +719,7 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
         end
 
         after do
-          described_class.class_variable_set(:@@logon_failures, nil) # rubocop:disable Style/ClassVars
+          described_class.instance_variable_set(:@logon_failures, [])
         end
 
         it 'errors specifically for a logon failure and returns nil' do
@@ -729,12 +728,12 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
 
         it 'caches the logon failure' do
           expect { result }.not_to raise_error
-          expect(described_class.class_variable_get(:@@logon_failures)).to eq([credential_hash])
+          expect(described_class.instance_variable_get(:@logon_failures)).to eq([credential_hash])
         end
 
         it 'caches the query results' do
           expect { result }.not_to raise_error
-          expect(described_class.class_variable_get(:@@cached_query_results)).to eq([name_hash])
+          expect(described_class.instance_variable_get(:@cached_query_results)).to eq([name_hash])
         end
       end
 
@@ -982,11 +981,11 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
   end
 
   describe '.invoke_test_method' do
-    subject(:result) { provider.invoke_test_method(context, name, test_should) }
+    subject(:result) { provider.invoke_test_method(context, name, expect(subject).to) }
 
     let(:name) { { name: 'foo', dsc_name: 'bar' } }
-    let(:test_should) { name.merge(dsc_ensure: 'present') }
-    let(:test_properties) { test_should.reject { |k, _v| k == :name } }
+    let(:should) { name.merge(dsc_ensure: 'present') }
+    let(:test_properties) { expect(subject).to.reject { |k, _v| k == :name } }
     let(:invoke_dsc_resource_data) { nil }
 
     before do
@@ -996,7 +995,7 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
     end
 
     after do
-      described_class.class_variable_set(:@@cached_test_results, []) # rubocop:disable Style/ClassVars
+      described_class.instance_variable_set(:@cached_test_results, [])
     end
 
     context 'when something went wrong calling Invoke-DscResource' do
@@ -1044,28 +1043,28 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
 
   describe '.instantiated_variables' do
     after do
-      described_class.class_variable_set(:@@instantiated_variables, nil) # rubocop:disable Style/ClassVars
+      described_class.instance_variable_set(:@instantiated_variables, [])
     end
 
-    it 'sets the instantiated_variables class variable to {} if not initialized' do
+    it 'sets the instantiated_variables instance variable to {} if not initialized' do
       expect(provider.instantiated_variables).to eq({})
     end
 
-    it 'returns the instantiated_variables class variable if already initialized' do
-      described_class.class_variable_set(:@@instantiated_variables, { foo: 'bar' }) # rubocop:disable Style/ClassVars
+    it 'returns the instantiated_variables instance variable if already initialized' do
+      described_class.instance_variable_set(:@instantiated_variables, { foo: 'bar' })
       expect(provider.instantiated_variables).to eq({ foo: 'bar' })
     end
   end
 
   describe '.clear_instantiated_variables!' do
     after do
-      described_class.class_variable_set(:@@instantiated_variables, nil) # rubocop:disable Style/ClassVars
+      described_class.instance_variable_set(:@instantiated_variables, [])
     end
 
-    it 'sets the instantiated_variables class variable to {}' do
-      described_class.class_variable_set(:@@instantiated_variables, { foo: 'bar' }) # rubocop:disable Style/ClassVars
+    it 'sets the instantiated_variables instance variable to {}' do
+      described_class.instance_variable_set(:@instantiated_variables, { foo: 'bar' })
       expect { provider.clear_instantiated_variables! }.not_to raise_error
-      expect(described_class.class_variable_get(:@@instantiated_variables)).to eq({})
+      expect(described_class.instance_variable_get(:@instantiated_variables)).to eq({})
     end
   end
 
@@ -1088,16 +1087,16 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
       end
 
       after do
-        described_class.class_variable_set(:@@logon_failures, nil) # rubocop:disable Style/ClassVars
+        described_class.instance_variable_set(:@logon_failures, [])
       end
 
       it 'returns false if there have been no failed logons with the username/password combination' do
-        described_class.class_variable_set(:@@logon_failures, [bad_credential_hash]) # rubocop:disable Style/ClassVars
+        described_class.instance_variable_set(:@logon_failures, [bad_credential_hash])
         expect(provider.logon_failed_already?(good_credential_hash)).to be(false)
       end
 
-      it 'returns true if the username/password specified are found in the logon_failures class variable' do
-        described_class.class_variable_set(:@@logon_failures, [good_credential_hash, bad_credential_hash]) # rubocop:disable Style/ClassVars
+      it 'returns true if the username/password specified are found in the logon_failures instance variable' do
+        described_class.instance_variable_set(:@logon_failures, [good_credential_hash, bad_credential_hash])
         expect(provider.logon_failed_already?(bad_credential_hash)).to be(true)
       end
     end
@@ -1511,7 +1510,7 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
       end
 
       after do
-        described_class.class_variable_set(:@@instantiated_variables, nil) # rubocop:disable Style/ClassVars
+        described_class.instance_variable_set(:@instantiated_variables, [])
       end
 
       it 'writes the ruby representation of the credentials as the value of a key named for the new variable into the instantiated_variables cache' do
@@ -1544,7 +1543,7 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
     subject(:result) { provider.prepare_cim_instances(test_resource) }
 
     after do
-      described_class.class_variable_set(:@@instantiated_variables, nil) # rubocop:disable Style/ClassVars
+      described_class.instance_variable_set(:@instantiated_variables, [])
     end
 
     context 'when a cim instance is passed without nested cim instances' do
@@ -1653,7 +1652,7 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
 
   describe '.format_ciminstance' do
     after do
-      described_class.class_variable_set(:@@instantiated_variables, nil) # rubocop:disable Style/ClassVars
+      described_class.instance_variable_set(:@instantiated_variables, [])
     end
 
     it 'defines and returns a new cim instance as a PowerShell variable, passing the class name and property hash' do
@@ -1669,7 +1668,7 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
     end
 
     it 'interpolates variables in the case of a cim instance containing a nested instance' do
-      described_class.class_variable_set(:@@instantiated_variables, { 'SomeVariable' => { 'bar' => 'ope' } }) # rubocop:disable Style/ClassVars
+      described_class.instance_variable_set(:@instantiated_variables, { 'SomeVariable' => { 'bar' => 'ope' } })
       property_hash = { 'foo' => { 'bar' => 'ope' } }
       expect(provider.format_ciminstance('foo', 'SomeClass', property_hash)).to match(/@\{'foo' = \$SomeVariable\}/)
     end


### PR DESCRIPTION
## Summary
This is a continuation of https://github.com/puppetlabs/ruby-pwsh/pull/204 by https://github.com/Hvid & https://github.com/ShawnHardwick.

Fixes https://github.com/puppetlabs/ruby-pwsh/issues/203 and https://github.com/puppetlabs/Puppet.Dsc/issues/242

This is just copied from the comment by https://github.com/ShawnHardwick


## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified. (By users in https://github.com/puppetlabs/ruby-pwsh/issues/203 and https://github.com/puppetlabs/Puppet.Dsc/issues/242)

We can say with confidence that this change **should not** break existing DSC functionality thanks to tests added from these issues:
https://github.com/puppetlabs/ruby-pwsh/issues/163
https://github.com/puppetlabs/ruby-pwsh/issues/164
https://github.com/puppetlabs/ruby-pwsh/issues/165

These tests thoroughly test changes to the dsc base provider against published dsc modules.