### PR TITLE
(maint) - Removed soon-to-be deprecated RSpec/FilePath cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,3 +17,11 @@ AllCops:
 # Disabled
 Style/ClassAndModuleChildren:
   Enabled: false
+
+####################################################
+# Cops below here due for deprecation
+####################################################
+# ``Rspec/FilePath`` is going to be deprecated in the next major release of rubocop >=3.0.0: see <https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FilePath>
+# As the new cops are already present, e.g., Rspec/SpecFilePathPathFormat, then disabling this in preparation
+RSpec/FilePath:
+  Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -131,19 +131,6 @@ RSpec/DescribeClass:
 RSpec/ExampleLength:
   Max: 70
 
-# Offense count: 7
-# Configuration parameters: Include, CustomTransform, IgnoreMethods, SpecSuffixOnly.
-# Include: **/*_spec*rb*, **/spec/**/*
-RSpec/FilePath:
-  Exclude:
-    - 'spec/acceptance/dsc/basic.rb'
-    - 'spec/acceptance/dsc/cim_instances.rb'
-    - 'spec/acceptance/dsc/class.rb'
-    - 'spec/acceptance/dsc/complex.rb'
-    - 'spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb'
-    - 'spec/unit/pwsh/version_spec.rb'
-    - 'spec/unit/pwsh/windows_powershell_spec.rb'
-
 # Offense count: 102
 # Configuration parameters: .
 # SupportedStyles: have_received, receive


### PR DESCRIPTION
## Summary

This PR is a follow on from a recent [puppet-lint PR](https://github.com/puppetlabs/puppet-lint/pull/157) to exclude the soon-to-be deprecated [Rspec/FilePath](https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FilePath) and to favour the new ``Rspec/SpecFilePathFormat`` instead.  

## Additional Context

Since this cop is going to be deprecated in the next major release of rubocop >=3.0.0 according to the documentation, I've:

* added the deprecation at the end of ``.rubocop.yml`` to highlight that it is deprecated; and
* raised an issue to track and remove the exclusion when rubocop is upgraded >= 3.0.  See https://github.com/puppetlabs/ruby-pwsh/issues/257

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
