### PR TITLE
(CAT-1617) - Always load vendored module in PSModulePath

### DIFF
--- a/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
+++ b/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
@@ -656,8 +656,8 @@ class Puppet::Provider::DscBaseProvider
     modified_string
   end
 
-  # Parses a resource definition (as from `invocable_resource`) and, if the resource is implemented
-  # as a PowerShell class, ensures the System environment variable for PSModulePath is munged to
+  # Parses a resource definition (as from `invocable_resource`) and
+  # ensures the System environment variable for PSModulePath is munged to
   # include the vendored PowerShell modules. Due to a bug in PSDesiredStateConfiguration, class-based
   # DSC Resources cannot be called via Invoke-DscResource by path, only by module name, *and* the
   # module must be discoverable in the system-level PSModulePath. The postscript for invocation has
@@ -666,8 +666,6 @@ class Puppet::Provider::DscBaseProvider
   # @param resource [Hash] a hash with the information needed to run `Invoke-DscResource`
   # @return [String] A multi-line string which sets the PSModulePath at the system level
   def munge_psmodulepath(resource)
-    return unless resource[:dscmeta_resource_implementation] == 'Class'
-
     vendor_path = resource[:vendored_modules_path].tr('/', '\\')
     <<~MUNGE_PSMODULEPATH.strip
       $UnmungedPSModulePath = [System.Environment]::GetEnvironmentVariable('PSModulePath','machine')


### PR DESCRIPTION
## Summary

Prior to this PR, the vendored dsc module would only be loading into the PSModulePath Env variable if the dsc resource type was implemented as a Class.

Now that DSC Modules seem to be taking the approach of abstracting the DscResource.Base into a seperate module which is then imported, we need to alter the PSModulePath Env variable to include the vendored modules path to ensure this module and its classes (Resource Base) are imported as expected.

Its worth noting that ruby-pwsh will only temporarily add the vendored module path to the PSModulePath Env variable during the puppet agent run, before removing it again in the Dsc resource post invocation script.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Fixes https://github.com/puppetlabs/ruby-pwsh/issues/262

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
