### PR TITLE
(maint) - Run all unit test files during rake spec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ require 'rspec/core/rake_task'
 require 'yard'
 
 RSpec::Core::RakeTask.new(:spec) do |t|
-  t.pattern = 'spec/unit/*_spec.rb'
+  t.pattern = 'spec/unit/**/*_spec.rb'
 end
 task default: :spec
 

--- a/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
+++ b/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
@@ -666,7 +666,7 @@ class Puppet::Provider::DscBaseProvider
   # @param resource [Hash] a hash with the information needed to run `Invoke-DscResource`
   # @return [String] A multi-line string which sets the PSModulePath at the system level
   def munge_psmodulepath(resource)
-    vendor_path = resource[:vendored_modules_path].tr('/', '\\')
+    vendor_path = resource[:vendored_modules_path]&.tr('/', '\\')
     <<~MUNGE_PSMODULEPATH.strip
       $UnmungedPSModulePath = [System.Environment]::GetEnvironmentVariable('PSModulePath','machine')
       $MungedPSModulePath = $env:PSModulePath + ';#{vendor_path}'


### PR DESCRIPTION
## Summary

Tests were removed by mistake during CONT-867, so subsequent test breakage at 3a9156a9af16a6ad3ff9a2bfa179adb18f4b9d28 was easily missed.
This reimplements the missing test cases to the spec rake task, and fixes the broken tests.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
