### PR TITLE
(CAT-1869) - Add configurable dsc_timeout

### DIFF
--- a/spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb
+++ b/spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb
@@ -541,7 +541,7 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
 
     context 'when the invocation script returns data without errors' do
       before do
-        allow(ps_manager).to receive(:execute).with(script).and_return({ stdout: 'DSC Data' })
+        allow(ps_manager).to receive(:execute).with(script, nil).and_return({ stdout: 'DSC Data' })
         allow(JSON).to receive(:parse).with('DSC Data').and_return(parsed_invocation_data)
         allow(Puppet::Pops::Time::Timestamp).to receive(:parse).with('2100-01-01').and_return('TimeStamp:2100-01-01')
         allow(provider).to receive(:fetch_cached_hashes).and_return([])
@@ -659,15 +659,15 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
     context 'when the DSC invocation errors' do
       it 'writes an error and returns nil' do
         expect(provider).not_to receive(:logon_failed_already?)
-        expect(ps_manager).to receive(:execute).with(script).and_return({ stdout: nil })
-        expect(context).to receive(:err).with('Nothing returned')
+        expect(ps_manager).to receive(:execute).with(script, nil).and_return({ stdout: nil })
+        expect(context).to receive(:err).with('Nothing returned.')
         expect(result).to be_nil
       end
     end
 
     context 'when handling DateTimes' do
       before do
-        allow(ps_manager).to receive(:execute).with(script).and_return({ stdout: 'DSC Data' })
+        allow(ps_manager).to receive(:execute).with(script, nil).and_return({ stdout: 'DSC Data' })
         allow(JSON).to receive(:parse).with('DSC Data').and_return(parsed_invocation_data)
         allow(provider).to receive(:fetch_cached_hashes).and_return([])
       end
@@ -719,7 +719,7 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
       context 'when the credential is invalid' do
         before do
           allow(provider).to receive(:logon_failed_already?).and_return(false)
-          allow(ps_manager).to receive(:execute).with(script).and_return({ stdout: 'DSC Data' })
+          allow(ps_manager).to receive(:execute).with(script, nil).and_return({ stdout: 'DSC Data' })
           allow(JSON).to receive(:parse).with('DSC Data').and_return({ 'errormessage' => dsc_logon_failure_error })
           allow(context).to receive(:err).with(name_hash[:name], puppet_logon_failure_error)
         end
@@ -783,7 +783,7 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
     context 'when the invocation script returns nil' do
       it 'errors via context but does not raise' do
         expect(ps_manager).to receive(:execute).and_return({ stdout: nil })
-        expect(context).to receive(:err).with('Nothing returned')
+        expect(context).to receive(:err).with('Nothing returned.')
         expect { result }.not_to raise_error
       end
     end
@@ -837,7 +837,7 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
 
     context 'when the invocation script returns data without errors' do
       it 'filters for the correct properties to invoke and returns the results' do
-        expect(ps_manager).to receive(:execute).with("Script: #{apply_props}").and_return({ stdout: '{"in_desired_state": true, "errormessage": null}' })
+        expect(ps_manager).to receive(:execute).with("Script: #{apply_props}", nil).and_return({ stdout: '{"in_desired_state": true, "errormessage": null}' })
         expect(context).not_to receive(:err)
         expect(result).to eq({ 'in_desired_state' => true, 'errormessage' => nil })
       end


### PR DESCRIPTION
## Summary
This PR introduces a new instance variable @timeout, set
to nil by default. A new method set_dsc_timeout is added to
handle the setting of @timeout based on the name_hash[:dsc_timeout]
value. This timeout specifies the number of seconds the ps_manager will
await the dsc invocation to return, before moving on.

The ps_manager.execute method call now includes the timeout value.
The error message for when output is nil has been updated to include
information about the timeout, if it is set.

Does not affect previous behaviour, therefore is completely backwards
compatible with previous versions.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
