### PR TITLE
(maint) - add disclaimer for script block logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ The following platforms are supported:
 - RedHat
 - Ubuntu
 
+## Limitations
+
+- When PowerShell [Script Block Logging](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_logging_windows?view=powershell-7.4#enabling-script-block-logging) is enabled, data marked as sensitive in your manifest may appear in these logs as plain text. It is **highly recommended**, by both Puppet and Microsoft, that you also enable [Protected Event Logging](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_logging_windows?view=powershell-7.4#protected-event-logging) alongside this to encrypt the logs to protect this information.
+
 ## License
 
 This codebase is licensed under Apache 2.0. However, the open source dependencies included in this codebase might be subject to other software licenses such as AGPL, GPL2.0, and MIT.


### PR DESCRIPTION
## Summary
This PR adds a warning the readme about the use of sensitive data with script block logging enabled. As per microsoft's own recommendation, protected event logging should also be enabled to encyrpt this data.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
