### PR TITLE
(maint) - Fix incorrect test for file_path

### DIFF
--- a/spec/unit/pwsh/util_spec.rb
+++ b/spec/unit/pwsh/util_spec.rb
@@ -105,8 +105,11 @@ RSpec.describe Pwsh::Util do
       expect(described_class.invalid_directories?('')).to be false
     end
 
-    it 'returns false if a file path is provided' do
-      expect(described_class.invalid_directories?(file_path)).to be false
+    it 'returns true if a file path is provided' do
+      expect(described_class).to receive(:on_windows?).and_return(true)
+      expect(File).to receive(:exist?).with(file_path).and_return(true)
+      expect(File).to receive(:directory?).with(file_path).and_return(false)
+      expect(described_class.invalid_directories?(file_path)).to be true
     end
 
     it 'returns false if one valid path is provided' do


### PR DESCRIPTION
## Summary
Fixes a unit test wrongly configured in https://github.com/puppetlabs/ruby-pwsh/pull/334.
The `invalid_directories?` method should return true if passed a path that exists, but is a file. As we did not stub File.exists? the incorrect test went unnoticed.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
