### PR TITLE
Change [System.Environment]::SetEnvironmentVariable() to Set-ItemProperty

### DIFF
--- a/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
+++ b/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
@@ -773,7 +773,7 @@ class Puppet::Provider::DscBaseProvider # rubocop:disable Metrics/ClassLength
     <<~MUNGE_PSMODULEPATH.strip
       $UnmungedPSModulePath = [System.Environment]::GetEnvironmentVariable('PSModulePath','machine')
       $MungedPSModulePath = $env:PSModulePath + ';#{vendor_path}'
-      [System.Environment]::SetEnvironmentVariable('PSModulePath', $MungedPSModulePath, [System.EnvironmentVariableTarget]::Machine)
+      Set-ItemProperty -Path 'HKLM:\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment' -Name 'PSModulePath' -Value $MungedPSModulePath
       $env:PSModulePath = [System.Environment]::GetEnvironmentVariable('PSModulePath','machine')
     MUNGE_PSMODULEPATH
   end

--- a/lib/puppet/provider/dsc_base_provider/invoke_dsc_resource_postscript.ps1
+++ b/lib/puppet/provider/dsc_base_provider/invoke_dsc_resource_postscript.ps1
@@ -6,7 +6,8 @@ Try {
 } Finally {
   If (![string]::IsNullOrEmpty($UnmungedPSModulePath)) {
     # Reset the PSModulePath
-    [System.Environment]::SetEnvironmentVariable('PSModulePath', $UnmungedPSModulePath, [System.EnvironmentVariableTarget]::Machine)
+    #[System.Environment]::SetEnvironmentVariable('PSModulePath', $UnmungedPSModulePath, [System.EnvironmentVariableTarget]::Machine) #commented becose of long execution time
+    Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' -Name 'PSModulePath' -Value $UnmungedPSModulePath
     $env:PSModulePath = [System.Environment]::GetEnvironmentVariable('PSModulePath', 'machine')
   }
 }

--- a/lib/puppet/provider/dsc_base_provider/invoke_dsc_resource_postscript.ps1
+++ b/lib/puppet/provider/dsc_base_provider/invoke_dsc_resource_postscript.ps1
@@ -6,7 +6,6 @@ Try {
 } Finally {
   If (![string]::IsNullOrEmpty($UnmungedPSModulePath)) {
     # Reset the PSModulePath
-    #[System.Environment]::SetEnvironmentVariable('PSModulePath', $UnmungedPSModulePath, [System.EnvironmentVariableTarget]::Machine) #commented becose of long execution time
     Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' -Name 'PSModulePath' -Value $UnmungedPSModulePath
     $env:PSModulePath = [System.Environment]::GetEnvironmentVariable('PSModulePath', 'machine')
   }

--- a/spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb
+++ b/spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb
@@ -1529,7 +1529,8 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
       end
 
       it 'updates the system PSModulePath to $MungedPSModulePath' do
-        expect(result).to match(/SetEnvironmentVariable\('PSModulePath', \$MungedPSModulePath/)
+        -Name 'PSModulePath' -Value $MungedPSModulePath
+        expect(result).to match(/-Name 'PSModulePath' -Value \$MungedPSModulePath/)
       end
 
       it 'sets the process level PSModulePath to the modified system PSModulePath' do

--- a/spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb
+++ b/spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb
@@ -1529,7 +1529,6 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
       end
 
       it 'updates the system PSModulePath to $MungedPSModulePath' do
-        -Name 'PSModulePath' -Value $MungedPSModulePath
         expect(result).to match(/-Name 'PSModulePath' -Value \$MungedPSModulePath/)
       end
 


### PR DESCRIPTION
## Summary
Here was the method of set PSPath-Variable changed from [System.Environment]::SetEnvironmentVariable() to Set-ItemProperty. This brings a performance advantage, because the function can have [System.Environment]::SetEnvironmentVariable() timeouts ([see also](https://stackoverflow.com/questions/4825967/environment-setenvironmentvariable-takes-a-long-time-to-set-a-variable-at-user-o)).

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
https://github.com/puppetlabs/ruby-pwsh/issues/363

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified.
