### PR TITLE
(CAT-2589) Add Ruby 4.0 / Puppet 9 lane, source gems from puppetcore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,12 @@ jobs:
       matrix:
         ruby_version:
           - '3.2'
+          - '4.0'
         include:
           - ruby_version: '3.2'
             puppet_version: '~> 8.0'
+          - ruby_version: '4.0'
+            puppet_version: '~> 9.0'
     name: "spec (ruby ${{ matrix.ruby_version }} | puppet ${{ matrix.puppet_version }})"
     uses: "puppetlabs/cat-github-actions/.github/workflows/gem_ci.yml@main"
     secrets: "inherit"
@@ -36,9 +39,12 @@ jobs:
       matrix:
         ruby_version:
           - "3.2"
+          - "4.0"
         include:
           - ruby_version: '3.2'
             puppet_version: '~> 8.0'
+          - ruby_version: '4.0'
+            puppet_version: '~> 9.0'
         runs_on:
           - "windows-latest"
     name: "acceptance (${{ matrix.runs_on}} ruby ${{ matrix.ruby_version }} | puppet ${{ matrix.puppet_version }})"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
   acceptance:
     needs: "spec"
     strategy:
+      fail-fast: false
       matrix:
         ruby_version:
           - "3.2"

--- a/.github/workflows/custom_acceptance.yml
+++ b/.github/workflows/custom_acceptance.yml
@@ -31,6 +31,10 @@ on:
         default: "ubuntu-latest"
         type: "string"
 
+env:
+  PUPPET_FORGE_TOKEN: ${{ secrets.PUPPET_FORGE_TOKEN || secrets.PUPPET_FORGE_TOKEN_PUBLIC }}
+  BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM: "forge-key:${{ secrets.PUPPET_FORGE_TOKEN || secrets.PUPPET_FORGE_TOKEN_PUBLIC }}"
+
 jobs:
   acceptance:
     name: "acceptance"
@@ -42,8 +46,9 @@ jobs:
         uses: "actions/checkout@v4"
 
       - name: "export environment"
+        shell: pwsh
         run: |
-          echo "PUPPET_GEM_VERSION=${{ inputs.puppet_version }} >> $GITHUB_ENV"
+          echo "PUPPET_GEM_VERSION=${{ inputs.puppet_version }}" >> $env:GITHUB_ENV
 
       - name: "setup ruby"
         uses: "ruby/setup-ruby@v1"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,6 +28,7 @@ jobs:
   acceptance:
     needs: "spec"
     strategy:
+      fail-fast: false
       matrix:
         ruby_version:
           - "3.2"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,9 +12,12 @@ jobs:
       matrix:
         ruby_version:
           - '3.2'
+          - '4.0'
         include:
           - ruby_version: '3.2'
             puppet_version: '~> 8.0'
+          - ruby_version: '4.0'
+            puppet_version: '~> 9.0'
     name: "spec (ruby ${{ matrix.ruby_version }} | puppet ${{ matrix.puppet_version }})"
     uses: "puppetlabs/cat-github-actions/.github/workflows/gem_ci.yml@main"
     secrets: "inherit"
@@ -28,9 +31,12 @@ jobs:
       matrix:
         ruby_version:
           - "3.2"
+          - "4.0"
         include:
           - ruby_version: '3.2'
             puppet_version: '~> 8.0'
+          - ruby_version: '4.0'
+            puppet_version: '~> 9.0'
         runs_on:
           - "windows-latest"
     name: "acceptance (${{ matrix.runs_on}} ruby ${{ matrix.ruby_version }} | puppet ${{ matrix.puppet_version }})"

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,13 @@
-source ENV['GEM_SOURCE'] || 'https://rubygems.org'
+# For puppetcore, set GEM_SOURCE_PUPPETCORE = 'https://rubygems-puppetcore.puppet.com'
+gemsource_default = ENV['GEM_SOURCE'] || 'https://rubygems.org'
+gemsource_puppetcore = if ENV['PUPPET_FORGE_TOKEN'] && !ENV['PUPPET_FORGE_TOKEN'].empty?
+                         'https://rubygems-puppetcore.puppet.com'
+                       else
+                         ENV['GEM_SOURCE_PUPPETCORE'] || gemsource_default
+                       end
+source gemsource_default
 
-def location_for(place_or_version, fake_version = nil)
+def location_for(place_or_version, fake_version = nil, opts = {})
   git_url_regex = %r{\A(?<url>(https?|git)[:@][^#]*)(#(?<branch>.*))?}
   file_url_regex = %r{\Afile:\/\/(?<path>.*)}
 
@@ -9,7 +16,7 @@ def location_for(place_or_version, fake_version = nil)
   elsif place_or_version && (file_url = place_or_version.match(file_url_regex))
     ['>= 0', { path: File.expand_path(file_url[:path]), require: false }]
   else
-    [place_or_version, { require: false }]
+    [place_or_version, { require: false }.merge(opts)]
   end
 end
 
@@ -47,7 +54,7 @@ hiera_version = ENV['HIERA_GEM_VERSION']
 
 gems = {}
 
-gems['puppet'] = location_for(puppet_version)
+gems['puppet'] = location_for(puppet_version, nil, { source: gemsource_puppetcore })
 
 # If facter or hiera versions have been specified via the environment
 # variables

--- a/Gemfile
+++ b/Gemfile
@@ -24,10 +24,10 @@ group :development do
   gem "json", '= 2.6.1',                         require: false if Gem::Requirement.create(['>= 3.1.0', '< 3.1.3']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.6.3',                         require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "deep_merge", '~> 1.0',                    require: false
-  gem "voxpupuli-puppet-lint-plugins", '~> 5.0', require: false
-  gem "facterdb", '~> 1.18',                     require: false
+  gem "voxpupuli-puppet-lint-plugins", '~> 7.0', require: false
+  gem "facterdb", '~> 4.0',                      require: false
   gem "metadata-json-lint", '~> 4.0',            require: false
-  gem "rspec-puppet-facts", '~> 3.0',            require: false
+  gem "rspec-puppet-facts", '~> 6.0',            require: false
   gem "dependency_checker", '~> 1.0.0',          require: false
   gem "parallel_tests", '3.13.0',              require: false
   gem "pry", '~> 0.10',                          require: false
@@ -40,7 +40,7 @@ group :development do
 end
 group :development, :release_prep do
   gem "puppet-strings", '~> 4.0',         require: false
-  gem "puppetlabs_spec_helper", '~> 8.0', require: false
+  gem "puppetlabs_spec_helper", '~> 9.0', require: false
 end
 group :system_tests do
   gem "puppet_litmus", '~> 1.0',   require: false, platforms: [:ruby, :x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ group :development, :release_prep do
 end
 group :system_tests do
   gem "CFPropertyList", '< 3.0.7', require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "ffi",                       require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "serverspec", '~> 2.41',     require: false
 end
 
@@ -55,12 +56,17 @@ hiera_version = ENV['HIERA_GEM_VERSION']
 
 gems = {}
 
+gemsource_facter = if Gem.ruby_version >= Gem::Version.new('4.0')
+                     gemsource_puppetcore
+                   else
+                     gemsource_default
+                   end
+
 gems['puppet'] = location_for(puppet_version, nil, { source: gemsource_puppetcore })
+gems['facter'] = location_for(facter_version, nil, { source: gemsource_facter })
 
-# If facter or hiera versions have been specified via the environment
-# variables
+# If a hiera version has been specified via the environment variable
 
-gems['facter'] = location_for(facter_version) if facter_version
 gems['hiera'] = location_for(hiera_version) if hiera_version
 
 gems.each do |gem_name, gem_params|

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ gemsource_puppetcore = if ENV['PUPPET_FORGE_TOKEN'] && !ENV['PUPPET_FORGE_TOKEN'
                        end
 source gemsource_default
 
+gem "rexml", require: false
+
 def location_for(place_or_version, fake_version = nil, opts = {})
   git_url_regex = %r{\A(?<url>(https?|git)[:@][^#]*)(#(?<branch>.*))?}
   file_url_regex = %r{\Afile:\/\/(?<path>.*)}
@@ -43,7 +45,6 @@ group :development, :release_prep do
   gem "puppetlabs_spec_helper", '~> 9.0', require: false
 end
 group :system_tests do
-  gem "puppet_litmus", '~> 1.0',   require: false, platforms: [:ruby, :x64_mingw]
   gem "CFPropertyList", '< 3.0.7', require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "serverspec", '~> 2.41',     require: false
 end

--- a/ruby-pwsh.gemspec
+++ b/ruby-pwsh.gemspec
@@ -28,6 +28,8 @@ Gem::Specification.new do |spec|
     'spec/**/*',
   ]
 
+  spec.add_dependency 'rexml'
+
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/spec/acceptance/dsc/cim_instances.rb
+++ b/spec/acceptance/dsc/cim_instances.rb
@@ -67,7 +67,7 @@ RSpec.describe 'DSC Acceptance: Complex' do
       expect(first_run_result[:exitcode]).to be(2)
       # Access Control Set
       expect(first_run_result[:native_stdout]).to match(/dsc_accesscontrollist: dsc_accesscontrollist changed/)
-      expect(first_run_result[:native_stdout]).to match(%r{dsc_ntfsaccessentry\[{:name=>"Test", :dsc_path=>".+/spec/fixtures/access_control"}\]: Updating: Finished})
+      expect(first_run_result[:native_stdout]).to match(%r{dsc_ntfsaccessentry\[\{:?name(?:=>|: )"Test", :?dsc_path(?:=>|: )".+/spec/fixtures/access_control"\}\]: Updating: Finished})
       expect(first_run_result[:stderr]).not_to match(/Error/)
       expect(first_run_result[:stderr]).not_to match(/Warning: Provider returned data that does not match the Type Schema/)
       expect(first_run_result[:stderr]).not_to match(/Value type mismatch/)

--- a/spec/acceptance/dsc/complex.rb
+++ b/spec/acceptance/dsc/complex.rb
@@ -114,10 +114,10 @@ RSpec.describe 'DSC Acceptance: Complex' do
       expect(first_run_result[:exitcode]).to be(2)
       # The Default Site is stopped
       expect(first_run_result[:native_stdout]).to match(%r{Dsc_xwebsite\[DefaultSite\]/dsc_state: dsc_state changed 'Started' to 'Stopped'})
-      expect(first_run_result[:native_stdout]).to match(/dsc_xwebsite\[{:name=>"DefaultSite", :dsc_name=>"Default Web Site"}\]: Updating: Finished/)
+      expect(first_run_result[:native_stdout]).to match(/dsc_xwebsite\[\{:?name(?:=>|: )"DefaultSite", :?dsc_name(?:=>|: )"Default Web Site"\}\]: Updating: Finished/)
       # AspNet45 is installed
       expect(first_run_result[:native_stdout]).to match(%r{Dsc_xwindowsfeature\[AspNet45\]/dsc_ensure: dsc_ensure changed 'Absent' to 'Present'})
-      expect(first_run_result[:native_stdout]).to match(/dsc_xwindowsfeature\[{:name=>"AspNet45", :dsc_name=>"Web-Asp-Net45"}\]: Creating: Finished/)
+      expect(first_run_result[:native_stdout]).to match(/dsc_xwindowsfeature\[\{:?name(?:=>|: )"AspNet45", :?dsc_name(?:=>|: )"Web-Asp-Net45"\}\]: Creating: Finished/)
       # Web content folder created
       expect(first_run_result[:native_stdout]).to match(%r{File\[WebContentFolder\]/ensure: created})
       # Web content index created
@@ -128,7 +128,7 @@ RSpec.describe 'DSC Acceptance: Complex' do
       expect(first_run_result[:native_stdout]).to match(%r{Dsc_xwebsite\[NewWebsite\]/dsc_physicalpath: dsc_physicalpath changed.*to '.+fixtures/website'})
       expect(first_run_result[:native_stdout]).to match(%r{Dsc_xwebsite\[NewWebsite\]/dsc_state: dsc_state changed.*to 'Started'})
       expect(first_run_result[:native_stdout]).to match(%r{Dsc_xwebsite\[NewWebsite\]/dsc_serverautostart: dsc_serverautostart changed.*to 'true'})
-      expect(first_run_result[:native_stdout]).to match(/dsc_xwebsite\[{:name=>"NewWebsite", :dsc_name=>"Puppet DSC Site"}\]: Creating: Finished/)
+      expect(first_run_result[:native_stdout]).to match(/dsc_xwebsite\[\{:?name(?:=>|: )"NewWebsite", :?dsc_name(?:=>|: )"Puppet DSC Site"\}\]: Creating: Finished/)
       # Run finished
       expect(first_run_result[:native_stdout]).to match(/Applied catalog/)
       # Second run is idempotent


### PR DESCRIPTION
## Summary

Adds Ruby 4.0 / Puppet 9 CI coverage to `ruby-pwsh`, mirroring the same update already carried out on other repos (e.g. `puppetlabs_spec_helper@3bfa7d21`, `bolt-private#120`):

- Add a `ruby_version: '4.0'` / `puppet_version: '~> 9.0'` matrix entry to the `spec` and `acceptance` jobs in `ci.yml` and `nightly.yml`, alongside the existing `3.2` / `~> 8.0` lane.
- Update the `Gemfile` to source the `puppet` gem from `rubygems-puppetcore.puppet.com` when `PUPPET_FORGE_TOKEN` is set (falls back to `GEM_SOURCE_PUPPETCORE` or the default gem source otherwise).
- Bump `puppetlabs_spec_helper` from `~> 8.0` to `~> 9.0` to pick up the CVE-fixed `puppetlabs-syntax` fork.

`ruby-pwsh` doesn't carry bolt's Gemfile Ruby-version-conditional/canary-spec workaround for the Puppet 8.x FrozenError-on-Ruby-4.0 bug, since its CI already explicitly pins `puppet_version` per matrix lane rather than resolving puppet dynamically from the runtime Ruby version — so that part of the bolt-private pattern doesn't apply here.

## Test plan

- [ ] CI passes on both the existing `ruby 3.2 | puppet ~> 8.0` lane and the new `ruby 4.0 | puppet ~> 9.0` lane, for both `spec` and `acceptance` jobs.