### PR TITLE
fix: allow empty string comparison

### DIFF
--- a/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
+++ b/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
@@ -550,9 +550,14 @@ class Puppet::Provider::DscBaseProvider # rubocop:disable Metrics/ClassLength
 
     return true if in_sync
 
-    # DSC Test says out of sync. Suppress non-dsc_ and nil/empty properties.
+    # DSC Test says out of sync. Suppress non-DSC, nil and empty collection
+    # properties. An empty String is an explicit valid DSC value and must be
+    # compared.
     return true unless property_name.to_s.start_with?('dsc_')
-    return true if should_value.nil? || (should_value.respond_to?(:empty?) && should_value.empty?)
+    return true if should_value.nil?
+    return true if !should_value.is_a?(String) &&
+                   should_value.respond_to?(:empty?) &&
+                   should_value.empty?
 
     # Fresh Get comparison for dsc_ properties with values
     compare_fresh_value(context, name, property_name, should_hash, report_on_failure: true)
@@ -563,7 +568,10 @@ class Puppet::Provider::DscBaseProvider # rubocop:disable Metrics/ClassLength
     return nil unless property_name.to_s.start_with?('dsc_')
 
     should_value = should_hash.is_a?(Hash) ? should_hash[property_name] : nil
-    return nil if should_value.nil? || (should_value.respond_to?(:empty?) && should_value.empty?)
+    return nil if should_value.nil?
+    return nil if !should_value.is_a?(String) &&
+                  should_value.respond_to?(:empty?) &&
+                  should_value.empty?
 
     compare_fresh_value(context, name, property_name, should_hash, report_on_failure: false)
   end

--- a/spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb
+++ b/spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb
@@ -493,8 +493,25 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
       end
 
       context 'when should_value is empty string' do
-        it 'returns nil' do
+        it 'compares the value' do
           should_hash_empty = should_hash.merge(dsc_setting: '')
+          allow(provider).to receive(:compare_fresh_value).and_return(true)
+          result = provider.send(:insync?, context, name, :dsc_setting, is_hash, should_hash_empty)
+          expect(result).to be(true)
+        end
+      end
+
+      context 'when should_value is empty array' do
+        it 'returns nil' do
+          should_hash_empty = should_hash.merge(dsc_setting: [])
+          result = provider.send(:insync?, context, name, :dsc_setting, is_hash, should_hash_empty)
+          expect(result).to be_nil
+        end
+      end
+
+      context 'when should_value is empty hash' do
+        it 'returns nil' do
+          should_hash_empty = should_hash.merge(dsc_setting: {})
           result = provider.send(:insync?, context, name, :dsc_setting, is_hash, should_hash_empty)
           expect(result).to be_nil
         end


### PR DESCRIPTION
This PR is created to execute tests for the original PR (https://github.com/puppetlabs/ruby-pwsh/pull/384)