### PR TITLE
Declare Puppet 9 support in metadata.json requirements

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -78,7 +78,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 8.0.0 < 9.0.0"
+      "version_requirement": ">= 8.0.0 < 10.0.0"
     }
   ],
   "pdk-version": "3.0.1",


### PR DESCRIPTION
## Summary
- CAT-2589 (#385, shipped in v2.1.0) added a validated Ruby 4.0 / Puppet 9 CI lane (`spec (ruby 4.0 | puppet ~> 9.0)`), but never widened the declared `requirements.puppet.version_requirement` bound.
- v2.1.0 is currently live on the Forge still declaring `puppet >= 8.0.0 < 9.0.0`, despite Puppet 9 already passing CI.
- This is blocking downstream modules (e.g. puppetlabs-dsc_lite) from being able to honestly widen their own puppet requirement to include 9.x while depending on pwshlib, since Puppet itself checks each module's declared `requirements.puppet` bound against the running Puppet version at catalog compile time.
- Bumped the bound from `< 9.0.0` to `< 10.0.0`.

## Test plan
- [x] `bundle exec dependency-checker metadata.json` passes locally
- [ ] Cut a v2.1.1 patch release once merged, so downstream modules can depend on a Forge release that declares Puppet 9 support

🤖 Generated with [Claude Code](https://claude.com/claude-code)